### PR TITLE
pod: use websocket exec with spdy fallback 

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -459,8 +460,11 @@ func (builder *Builder) ExecCommand(command []string, containerName ...string) (
 			TTY:       true,
 		}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(builder.apiClient.Config, "POST", req.URL())
+	exec, err := builder.getExecutorFromRequest(req)
 	if err != nil {
+		glog.V(100).Infof("Could not create command executor for pod %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
+
 		return buffer, err
 	}
 
@@ -538,7 +542,7 @@ func (builder *Builder) ExecCommandWithTimeout(
 			TTY:       true,
 		}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(builder.apiClient.Config, "POST", req.URL())
+	exec, err := builder.getExecutorFromRequest(req)
 	if err != nil {
 		return buffer, err
 	}
@@ -600,35 +604,11 @@ func (builder *Builder) Copy(path, containerName string, tar bool) (bytes.Buffer
 			TTY:       false,
 		}, scheme.ParameterCodec)
 
-	tlsConfig, err := rest.TLSConfigFor(builder.apiClient.Config)
+	exec, err := builder.getExecutorFromRequest(req)
 	if err != nil {
-		return bytes.Buffer{}, err
-	}
+		glog.V(100).Infof("Could not create executor to copy from pod %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
 
-	proxy := http.ProxyFromEnvironment
-	if builder.apiClient.Config.Proxy != nil {
-		proxy = builder.apiClient.Config.Proxy
-	}
-
-	// More verbose setup of remotecommand executor required in order to tweak PingPeriod.
-	// By default many large files are not copied in their entirety without disabling PingPeriod during the copy.
-	// https://github.com/kubernetes/kubernetes/issues/60140#issuecomment-1411477275
-	upgradeRoundTripper, err := spdy.NewRoundTripperWithConfig(spdy.RoundTripperConfig{
-		TLS:        tlsConfig,
-		Proxier:    proxy,
-		PingPeriod: 0,
-	})
-	if err != nil {
-		return bytes.Buffer{}, err
-	}
-
-	wrapper, err := rest.HTTPWrappersForConfig(builder.apiClient.Config, upgradeRoundTripper)
-	if err != nil {
-		return bytes.Buffer{}, err
-	}
-
-	exec, err := remotecommand.NewSPDYExecutorForTransports(wrapper, upgradeRoundTripper, "POST", req.URL())
-	if err != nil {
 		return buffer, err
 	}
 
@@ -1280,6 +1260,59 @@ func (builder *Builder) GetLogsWithOptions(options *corev1.PodLogOptions) ([]byt
 // GetGVR returns pod's GroupVersionResource which could be used for Clean function.
 func GetGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+}
+
+// getExecutorFromRequest returns a new Executor using the builder's apiClient and the request. It attempts to first use
+// the websocket executor then falls back to using the SPDY executor with pings disabled. This should maximize
+// reliability by avoiding issues like kubernetes/kubernetes#60140 and kubernetes/kubernetes#124571.
+//
+//nolint:ireturn // remotecommand only returns interfaces, so we must too.
+func (builder *Builder) getExecutorFromRequest(req *rest.Request) (remotecommand.Executor, error) {
+	tlsConfig, err := rest.TLSConfigFor(builder.apiClient.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := http.ProxyFromEnvironment
+	if builder.apiClient.Config.Proxy != nil {
+		proxy = builder.apiClient.Config.Proxy
+	}
+
+	// More verbose setup of remotecommand executor required in order to tweak PingPeriod. By default many large
+	// files are not copied in their entirety without disabling PingPeriod during the copy.
+	// https://github.com/kubernetes/kubernetes/issues/60140#issuecomment-1411477275
+	upgradeRoundTripper, err := spdy.NewRoundTripperWithConfig(spdy.RoundTripperConfig{
+		TLS:        tlsConfig,
+		Proxier:    proxy,
+		PingPeriod: 0,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	wrapper, err := rest.HTTPWrappersForConfig(builder.apiClient.Config, upgradeRoundTripper)
+	if err != nil {
+		return nil, err
+	}
+
+	spdyExec, err := remotecommand.NewSPDYExecutorForTransports(wrapper, upgradeRoundTripper, "POST", req.URL())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new SPDY executor: %w", err)
+	}
+
+	webSocketExec, err := remotecommand.NewWebSocketExecutor(builder.apiClient.Config, "GET", req.URL().String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new WebSocket executor: %w", err)
+	}
+
+	exec, err := remotecommand.NewFallbackExecutor(webSocketExec, spdyExec, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new fallback executor: %w", err)
+	}
+
+	return exec, nil
 }
 
 func getDefinition(name, nsName string) *corev1.Pod {


### PR DESCRIPTION
Depends-on: https://github.com/openshift-kni/eco-goinfra/pull/947

Currently, the pod package always uses the SPDY executor for executing commands. However, in Kubernetes 1.30, the websocket executor graduated to beta and is now enabled by default. This PR uses the FallbackExecutor to default to the websocket executor and only fallback to the SPDY executor if the websocket executor is unavailable.

Notably, the websocket executor should fix the issue of the stdout being truncated unexpectedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of pod exec and file copy by adding automatic protocol fallback, reducing failures behind restrictive proxies or on upgrade errors.
  * Enhanced error handling and logging for exec/copy, giving clearer messages when connections cannot be established.
  * No changes to public APIs or user-facing commands; behavior remains the same with increased robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->