### PR TITLE
nmstate policy add bond options

### DIFF
--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -257,7 +257,8 @@ func (builder *PolicyBuilder) WithInterfaceAndVFs(sriovInterface string, numberO
 }
 
 // WithBondInterface adds Bond interface configuration to the NodeNetworkConfigurationPolicy.
-func (builder *PolicyBuilder) WithBondInterface(slavePorts []string, bondName, mode string) *PolicyBuilder {
+func (builder *PolicyBuilder) WithBondInterface(slavePorts []string, bondName, mode string,
+	options ...OptionsLinkAggregation) *PolicyBuilder {
 	if valid, err := builder.validate(); !valid {
 		builder.errorMsg = err.Error()
 
@@ -291,6 +292,10 @@ func (builder *PolicyBuilder) WithBondInterface(slavePorts []string, bondName, m
 			Mode: mode,
 			Port: slavePorts,
 		},
+	}
+
+	if len(options) > 0 {
+		newInterface.LinkAggregation.Options = options[0]
 	}
 
 	return builder.withInterface(newInterface)

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -282,6 +282,9 @@ func TestPolicyWithWithBondInterface(t *testing.T) {
 		slavePorts        []string
 		bondName          string
 		mode              string
+		miimon            int
+		lacpRate          string
+		minLinks          int
 		expectedError     string
 	}{
 		{
@@ -290,6 +293,9 @@ func TestPolicyWithWithBondInterface(t *testing.T) {
 			slavePorts:        []string{"ens1", "ens2"},
 			bondName:          "bd1",
 			mode:              "active-backup",
+			miimon:            100,
+			lacpRate:          "fast",
+			minLinks:          1,
 		},
 		{
 			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
@@ -297,6 +303,9 @@ func TestPolicyWithWithBondInterface(t *testing.T) {
 			slavePorts:        []string{"ens1", "ens2"},
 			bondName:          "",
 			mode:              "active-backup",
+			miimon:            100,
+			lacpRate:          "fast",
+			minLinks:          1,
 		},
 		{
 			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
@@ -304,10 +313,29 @@ func TestPolicyWithWithBondInterface(t *testing.T) {
 			slavePorts:        []string{"ens1", "ens2"},
 			bondName:          "bd1",
 			mode:              "",
+			miimon:            100,
+			lacpRate:          "fast",
+			minLinks:          1,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "",
+			slavePorts:        []string{"ens1", "ens2"},
+			bondName:          "bd1",
+			mode:              "active-backup",
+			miimon:            0,
+			lacpRate:          "",
+			minLinks:          0,
 		},
 	}
 	for _, testCase := range testCases {
-		testPolicy := testCase.testNMStatePolicy.WithBondInterface(testCase.slavePorts, testCase.bondName, testCase.mode)
+		options := OptionsLinkAggregation{
+			Miimon:   testCase.miimon,
+			LacpRate: testCase.lacpRate,
+			MinLinks: testCase.minLinks,
+		}
+		testPolicy := testCase.testNMStatePolicy.WithBondInterface(testCase.slavePorts, testCase.bondName,
+			testCase.mode, options)
 		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
 
 		desireState := &DesiredState{}
@@ -322,6 +350,11 @@ func TestPolicyWithWithBondInterface(t *testing.T) {
 						LinkAggregation: LinkAggregation{
 							Mode: testCase.mode,
 							Port: testCase.slavePorts,
+							Options: OptionsLinkAggregation{
+								Miimon:   testCase.miimon,
+								LacpRate: testCase.lacpRate,
+								MinLinks: testCase.minLinks,
+							},
 						},
 					},
 				},

--- a/pkg/nmstate/shared.go
+++ b/pkg/nmstate/shared.go
@@ -85,6 +85,8 @@ type OptionsLinkAggregation struct {
 	Primary     string `yaml:"primary,omitempty"`
 	Miimon      int    `yaml:"miimon,omitempty"`
 	FailOverMac string `yaml:"fail_over_mac,omitempty"`
+	LacpRate    string `yaml:"lacp_rate,omitempty"`
+	MinLinks    int    `yaml:"min_links,omitempty"`
 }
 
 // Vlan provides struct for the NMState Interface Ethernet Vlan Options state object


### PR DESCRIPTION
Add lacp-rate as an option to the nmstate policy bond deployment. 