### PR TITLE
Update runners to 24.04

### DIFF
--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
       ECO_GOTESTS_PATH: gotests

--- a/.github/workflows/integration-testing-nightly.yml
+++ b/.github/workflows/integration-testing-nightly.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
 
@@ -38,7 +38,7 @@ jobs:
         run: make lint
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
 

--- a/.github/workflows/sync-libs.yaml
+++ b/.github/workflows/sync-libs.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       pr-url: ${{ steps.create-pr.outputs.pull-request-url }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
 


### PR DESCRIPTION
Experiment with updating our runners to 24.04.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated CI runners from Ubuntu 22.04 to Ubuntu 24.04 across integration test matrices (including ARM variants), nightly jobs, Kubernetes/OpenShift workflows, lint/test pipelines, and library sync tasks.
  * No changes to workflow steps, environment settings, logic, or public interfaces.
  * Affects CI infrastructure only; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->