### PR TITLE
Fix linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.25"
 linters:
   enable:
     - asciicheck
@@ -40,7 +40,8 @@ linters:
     - unparam
     - usetesting
     - varnamelen
-    - wsl
+    # Temporarily disable whitespace-stylistic linter due to high noise
+    # - wsl_v5
   settings:
     depguard:
       rules:
@@ -123,8 +124,12 @@ linters:
         - -SA1006
         - -ST1000
         - ST1001
-    wsl:
-      strict-append: false
+    # wsl_v5:
+    #   allow-first-in-block: true
+    #   allow-whole-block: false
+    #   branch-max-lines: 2
+    #   disable:
+    #     - append
   exclusions:
     generated: lax
     presets:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,8 +40,7 @@ linters:
     - unparam
     - usetesting
     - varnamelen
-    # Temporarily disable whitespace-stylistic linter due to high noise
-    # - wsl_v5
+    - wsl_v5
   settings:
     depguard:
       rules:
@@ -124,12 +123,12 @@ linters:
         - -SA1006
         - -ST1000
         - ST1001
-    # wsl_v5:
-    #   allow-first-in-block: true
-    #   allow-whole-block: false
-    #   branch-max-lines: 2
-    #   disable:
-    #     - append
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
+      disable:
+        - append
   exclusions:
     generated: lax
     presets:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ vet:
 
 lint:
 	@echo "Running go lint"
-	scripts/golangci-lint.sh
+	env -u BASH_ENV scripts/golangci-lint.sh
 
 deps-update:
 	go mod tidy && \

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -74,7 +74,6 @@ func syncRemoteRepo(repo *repo) {
 
 	if _, err := os.Stat(path.Join(basePath, repo.Name)); !os.IsNotExist(err) {
 		err := os.RemoveAll(path.Join(basePath, repo.Name))
-
 		if err != nil {
 			glog.V(100).Infof("Failed to remove cloned directory %s exit with error code 1",
 				path.Join(basePath, repo.Name))
@@ -105,7 +104,6 @@ func excludeAndRefactor(clonedDir, localDir string, repo *repo) {
 		fmt.Sprintf("package %s", path.Base(clonedDir)),
 		fmt.Sprintf("package %s", path.Base(localDir)),
 		clonedDir, "*.go")
-
 	if err != nil {
 		glog.V(100).Infof("Failed to replace package names due to %w. Exit with error 1", err)
 		os.Exit(1)
@@ -152,7 +150,6 @@ func gitClone(localPath string, repo *repo) {
 			"Local directory already exists for the project: %s. Removing directory", repo.Name)
 
 		err := os.RemoveAll(localDirectory)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to remove repo directory %s due to %w exit with error code 1",
 				localDirectory, err)
@@ -164,21 +161,18 @@ func gitClone(localPath string, repo *repo) {
 		localPath,
 		"git",
 		[]string{"clone", "-n", "--depth=1", "--filter=tree:0", "-b", repo.Branch, repo.RepoLink, repo.Name})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to clone repo due to cmd error. Exit with error code 1")
 		os.Exit(1)
 	}
 
 	err = execCmd(localDirectory, "git", []string{"sparse-checkout", "set", "--no-cone", repo.RemoteAPIDirectory})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to sparse-checkout repo due to cmd error. Exit with error code 1")
 		os.Exit(1)
 	}
 
 	err = execCmd(localDirectory, "git", []string{"checkout"})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to checkout repo due to cmd error. Exit with error code 1")
 		os.Exit(1)
@@ -195,7 +189,6 @@ func execCmd(dirName, binary string, args []string) error {
 	}
 
 	out, err := cmd.Output()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to execute cmd due to %s. Output: %s", err, string(out))
 
@@ -215,8 +208,8 @@ func newConfig(pathToConfigFiles string) []repo {
 			glog.V(100).Infof("Loading config file %s", info.Name())
 
 			var config []repo
-			err := readFile(&config, path)
 
+			err := readFile(&config, path)
 			if err != nil {
 				glog.V(100).Infof("Error to read config file: %w", err)
 
@@ -228,7 +221,6 @@ func newConfig(pathToConfigFiles string) []repo {
 
 		return nil
 	})
-
 	if err != nil {
 		glog.V(100).Infof("Error to list files in directory %s due to %w", pathToConfigFiles, err)
 
@@ -253,8 +245,8 @@ func readFile(cfg *[]repo, cfgFile string) error {
 	defer openedCfgFile.Close()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&cfg)
 
+	err = decoder.Decode(&cfg)
 	if err != nil {
 		return err
 	}
@@ -280,8 +272,8 @@ func refactorFunc(oldLine, newLine string, filePatterns []string) fs.WalkDirFunc
 
 		for _, pattern := range filePatterns {
 			var err error
-			matched, err = filepath.Match(pattern, dirEntry.Name())
 
+			matched, err = filepath.Match(pattern, dirEntry.Name())
 			if err != nil {
 				return err
 			}

--- a/pkg/amdgpu/deviceconfig.go
+++ b/pkg/amdgpu/deviceconfig.go
@@ -136,11 +136,11 @@ func (builder *Builder) Get() (*amdgpuv1.DeviceConfig, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	deviceConfig := &amdgpuv1.DeviceConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, deviceConfig)
-
 	if err != nil {
 		glog.V(100).Infof("DeviceConfig object %s does not exist in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)
@@ -162,8 +162,8 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect DeviceConfig object due to %s", err.Error())
 	}
@@ -190,7 +190,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("cannot delete DeviceConfig: %w", err)
 	}
@@ -212,7 +211,6 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -231,14 +229,12 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("DeviceConfig", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("DeviceConfig", builder.Definition.Name, builder.Definition.Namespace))
@@ -262,7 +258,6 @@ func getDeviceConfigFromAlmExample(almExample string) (*amdgpuv1.DeviceConfig, e
 	}
 
 	err := json.Unmarshal([]byte(almExample), &deviceConfigList.Items)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiservers/kubeapiserver.go
+++ b/pkg/apiservers/kubeapiserver.go
@@ -66,8 +66,8 @@ func (builder *KubeAPIServerBuilder) Exists() bool {
 	}
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect kubeAPIServer object due to %s", err.Error())
 	}
@@ -82,10 +82,10 @@ func (builder *KubeAPIServerBuilder) Get() (*operatorV1.KubeAPIServer, error) {
 	}
 
 	kubeAPIServer := &operatorV1.KubeAPIServer{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, kubeAPIServer)
-
 	if err != nil {
 		glog.V(100).Infof("kubeAPIServer object does not exist")
 
@@ -112,7 +112,6 @@ func (builder *KubeAPIServerBuilder) GetCondition(conditionType string) (*operat
 	}
 
 	kubeAPIServer, err := builder.Get()
-
 	if err != nil {
 		return nil, "", err
 	}
@@ -147,7 +146,6 @@ func (builder *KubeAPIServerBuilder) WaitUntilConditionTrue(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, errMsg = builder.Get()
-
 			if errMsg != nil {
 				return false, nil
 			}
@@ -168,7 +166,6 @@ func (builder *KubeAPIServerBuilder) WaitUntilConditionTrue(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("%w: %w", errMsg, err)
 	}
@@ -183,7 +180,6 @@ func (builder *KubeAPIServerBuilder) WaitAllNodesAtTheLatestRevision(timeout tim
 	verificationStr := "AllNodesAtLatestRevision"
 
 	err := builder.WaitUntilConditionTrue(conditionType, timeout)
-
 	if err != nil {
 		return err
 	}
@@ -193,7 +189,6 @@ func (builder *KubeAPIServerBuilder) WaitAllNodesAtTheLatestRevision(timeout tim
 			var err error
 
 			_, reasonMsg, err := builder.GetCondition(conditionType)
-
 			if err != nil {
 				return false, nil
 			}
@@ -206,7 +201,6 @@ func (builder *KubeAPIServerBuilder) WaitAllNodesAtTheLatestRevision(timeout tim
 
 			return true, nil
 		})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/apiservers/openshiftapiserver.go
+++ b/pkg/apiservers/openshiftapiserver.go
@@ -66,8 +66,8 @@ func (builder *OpenshiftAPIServerBuilder) Exists() bool {
 	}
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect openshiftAPIServer object due to %s", err.Error())
 	}
@@ -82,10 +82,10 @@ func (builder *OpenshiftAPIServerBuilder) Get() (*operatorV1.OpenShiftAPIServer,
 	}
 
 	openshiftAPIServer := &operatorV1.OpenShiftAPIServer{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, openshiftAPIServer)
-
 	if err != nil {
 		glog.V(100).Infof("openshiftAPIServer object does not exist")
 
@@ -113,7 +113,6 @@ func (builder *OpenshiftAPIServerBuilder) GetCondition(conditionType string) (
 	}
 
 	openshiftAPIServer, err := builder.Get()
-
 	if err != nil {
 		return nil, "", err
 	}
@@ -148,7 +147,6 @@ func (builder *OpenshiftAPIServerBuilder) WaitUntilConditionTrue(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, errMsg = builder.Get()
-
 			if errMsg != nil {
 				return false, nil
 			}
@@ -169,7 +167,6 @@ func (builder *OpenshiftAPIServerBuilder) WaitUntilConditionTrue(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("%w: %w", errMsg, err)
 	}
@@ -184,7 +181,6 @@ func (builder *OpenshiftAPIServerBuilder) WaitAllPodsAtTheLatestGeneration(timeo
 	verificationStr := "AsExpected"
 
 	err := builder.WaitUntilConditionTrue(conditionType, timeout)
-
 	if err != nil {
 		return err
 	}
@@ -198,7 +194,6 @@ func (builder *OpenshiftAPIServerBuilder) WaitAllPodsAtTheLatestGeneration(timeo
 			var err error
 
 			_, reasonMsg, err := builder.GetCondition(conditionType)
-
 			if err != nil {
 				return false, nil
 			}
@@ -211,7 +206,6 @@ func (builder *OpenshiftAPIServerBuilder) WaitAllPodsAtTheLatestGeneration(timeo
 
 			return true, nil
 		})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/argocd/applications.go
+++ b/pkg/argocd/applications.go
@@ -91,6 +91,7 @@ func (builder *ApplicationBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -106,11 +107,11 @@ func (builder *ApplicationBuilder) Get() (*argocdtypes.Application, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	application := &argocdtypes.Application{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, application)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"Failed to Get Application object in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
@@ -297,6 +298,7 @@ func (builder *ApplicationBuilder) WaitForCondition(
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
@@ -322,7 +324,6 @@ func (builder *ApplicationBuilder) WaitForCondition(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}
@@ -348,8 +349,8 @@ func (builder *ApplicationBuilder) DoesGitPathExist(elements ...string) bool {
 	}
 
 	repoURL := strings.TrimSuffix(builder.Definition.Spec.Source.RepoURL, ".git")
-	rawURL, err := url.ParseRequestURI(repoURL)
 
+	rawURL, err := url.ParseRequestURI(repoURL)
 	if err != nil {
 		glog.V(100).Infof("Failed to parse repo URL %s: %v", builder.Definition.Spec.Source.RepoURL, err)
 
@@ -417,8 +418,8 @@ func (builder *ApplicationBuilder) WaitForSourceUpdate(synced bool, timeout time
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Infof("Failed to get Argo CD Application %s in namespace %s: %v",
 					builder.Definition.Name, builder.Definition.Namespace, err)

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -131,6 +131,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -146,11 +147,11 @@ func (builder *Builder) Get() (*argocdoperator.ArgoCD, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	argocd := &argocdoperator.ArgoCD{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, argocd)
-
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +198,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete argocd: %w", err)
 	}
@@ -216,14 +216,12 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	glog.V(100).Infof("Updating the argocd object", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("argocd", builder.Definition.Name))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("argocd", builder.Definition.Name))

--- a/pkg/assisted/agent.go
+++ b/pkg/assisted/agent.go
@@ -191,17 +191,16 @@ func (builder *agentBuilder) WaitForState(state string, timeout time.Duration) (
 
 	// Polls every retryInterval to determine if agent is in desired state.
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
 
 			return builder.Object.Status.DebugInfo.State == state, nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -220,17 +219,16 @@ func (builder *agentBuilder) WaitForStateInfo(stateInfo string, timeout time.Dur
 
 	// Polls every retryInterval to determine if agent is in desired state.
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
 
 			return builder.Object.Status.DebugInfo.StateInfo == stateInfo, nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -249,7 +247,6 @@ func (builder *agentBuilder) WithOptions(options ...AgentAdditionalOptions) *age
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -278,7 +275,6 @@ func (builder *agentBuilder) Get() (*agentInstallV1Beta1.Agent, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, agent)
-
 	if err != nil {
 		return nil, err
 	}
@@ -321,6 +317,7 @@ func (builder *agentBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -345,7 +342,6 @@ func (builder *agentBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete agent: %w", err)
 	}

--- a/pkg/assisted/agentclusterinstall.go
+++ b/pkg/assisted/agentclusterinstall.go
@@ -330,17 +330,16 @@ func (builder *AgentClusterInstallBuilder) WaitForState(
 
 	// Polls every second to determine if agentclusterinstall in desired state.
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
 
 			return builder.Object.Status.DebugInfo.State == state, err
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -358,17 +357,16 @@ func (builder *AgentClusterInstallBuilder) WaitForStateInfo(
 
 	// Polls every second to determine if agentclusterinstall has the desired stateinfo message.
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
 
 			return builder.Object.Status.DebugInfo.StateInfo == stateInfo, err
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -388,7 +386,6 @@ func (builder *AgentClusterInstallBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -506,7 +503,6 @@ func (builder *AgentClusterInstallBuilder) Get() (*hiveextV1Beta1.AgentClusterIn
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, agentClusterInstall)
-
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +592,6 @@ func (builder *AgentClusterInstallBuilder) Update(force bool) (*AgentClusterInst
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -688,6 +683,7 @@ func (builder *AgentClusterInstallBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -714,7 +710,6 @@ func (builder *AgentClusterInstallBuilder) getCondition(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return nil, fmt.Errorf("error while waiting for conditions to be published: %w", err)
 	}

--- a/pkg/assisted/agentclusterinstall_test.go
+++ b/pkg/assisted/agentclusterinstall_test.go
@@ -413,18 +413,15 @@ func TestAgentClusterInstallWithOptions(t *testing.T) {
 				return builder, nil
 			},
 			validator: func(acib *AgentClusterInstallBuilder) bool {
-
 				return acib.Definition.Spec.IgnitionEndpoint.Url == "https://some.ign.endpoint.com"
 			},
 			expectedError: "",
 		},
 		{
 			option: func(builder *AgentClusterInstallBuilder) (*AgentClusterInstallBuilder, error) {
-
 				return builder, fmt.Errorf("agentclusterinstallbuilder contains error")
 			},
 			validator: func(acib *AgentClusterInstallBuilder) bool {
-
 				return acib.errorMsg != ""
 			},
 			expectedError: "agentclusterinstallbuilder contains error",

--- a/pkg/assisted/agentserviceconfig.go
+++ b/pkg/assisted/agentserviceconfig.go
@@ -236,7 +236,6 @@ func (builder *AgentServiceConfigBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -268,10 +267,10 @@ func (builder *AgentServiceConfigBuilder) WaitUntilDeployed(timeout time.Duratio
 	conditionIndex := -1
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
@@ -290,7 +289,6 @@ func (builder *AgentServiceConfigBuilder) WaitUntilDeployed(timeout time.Duratio
 
 			return builder.Object.Status.Conditions[conditionIndex].Status == "True", nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -340,7 +338,6 @@ func (builder *AgentServiceConfigBuilder) Get() (*agentInstallV1Beta1.AgentServi
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, agentServiceConfig)
-
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +382,6 @@ func (builder *AgentServiceConfigBuilder) Update(force bool) (*AgentServiceConfi
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -432,7 +428,6 @@ func (builder *AgentServiceConfigBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete agentserviceconfig: %w", err)
 	}
@@ -479,6 +474,7 @@ func (builder *AgentServiceConfigBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/assisted/infraenv.go
+++ b/pkg/assisted/infraenv.go
@@ -259,7 +259,6 @@ func (builder *InfraEnvBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -281,17 +280,16 @@ func (builder *InfraEnvBuilder) WaitForDiscoveryISOCreation(timeout time.Duratio
 
 	// Polls every retryInterval to determine if infraenv in desired state.
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
 
 			return builder.Object.Status.CreatedTime != nil, nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -451,7 +449,6 @@ func (builder *InfraEnvBuilder) WaitForAgentsToRegister(timeout time.Duration) (
 	}
 
 	agentclusterinstall, err := builder.GetAgentClusterInstallFromInfraEnv()
-
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +462,6 @@ func (builder *InfraEnvBuilder) WaitForAgentsToRegister(timeout time.Duration) (
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			agentList, err = builder.GetAllAgents()
-
 			if err != nil {
 				return false, err
 			}
@@ -484,7 +480,6 @@ func (builder *InfraEnvBuilder) WaitForMasterAgents(timeout time.Duration) ([]*a
 	}
 
 	agentclusterinstall, err := builder.GetAgentClusterInstallFromInfraEnv()
-
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +555,6 @@ func (builder *InfraEnvBuilder) WaitForWorkerAgents(timeout time.Duration) ([]*a
 	}
 
 	agentclusterinstall, err := builder.GetAgentClusterInstallFromInfraEnv()
-
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +659,6 @@ func (builder *InfraEnvBuilder) GetAgentClusterInstallFromInfraEnv() (*hiveextV1
 		Name:      builder.Object.Spec.ClusterRef.Name,
 		Namespace: builder.Object.Spec.ClusterRef.Namespace,
 	}, &clusterdeployment)
-
 	if err != nil {
 		glog.V(100).Infof("Unable to get clusterdeployment %s referenced by infraenv %s",
 			builder.Object.Spec.ClusterRef.Name, builder.Definition.Name)
@@ -682,7 +675,6 @@ func (builder *InfraEnvBuilder) GetAgentClusterInstallFromInfraEnv() (*hiveextV1
 		Name:      clusterdeployment.Spec.ClusterInstallRef.Name,
 		Namespace: clusterdeployment.Namespace,
 	}, &agentclusterinstall)
-
 	if err != nil {
 		glog.V(100).Infof("Unable to get agentclusterinstall %s referenced by clusterdeployment %s",
 			clusterdeployment.Spec.ClusterInstallRef.Name, clusterdeployment.Name)
@@ -708,7 +700,6 @@ func (builder *InfraEnvBuilder) Get() (*agentInstallV1Beta1.InfraEnv, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, infraEnv)
-
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +785,6 @@ func (builder *InfraEnvBuilder) Update(force bool) (*InfraEnvBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -843,7 +833,6 @@ func (builder *InfraEnvBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete infraenv: %w", err)
 	}
@@ -889,6 +878,7 @@ func (builder *InfraEnvBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/assisted/nmstateconfig.go
+++ b/pkg/assisted/nmstateconfig.go
@@ -76,6 +76,7 @@ func (builder *NmStateConfigBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -91,11 +92,11 @@ func (builder *NmStateConfigBuilder) Get() (*assistedv1beta1.NMStateConfig, erro
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nmStateConfig := &assistedv1beta1.NMStateConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nmStateConfig)
-
 	if err != nil {
 		glog.V(100).Infof("nmstateconfig object %s does not exist", builder.Definition.Name)
 
@@ -135,7 +136,6 @@ func (builder *NmStateConfigBuilder) Delete() error {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete nmstateconfig: %w", err)
 	}
@@ -156,7 +156,6 @@ func ListNmStateConfigsInAllNamespaces(apiClient *clients.Settings) ([]*NmStateC
 	}
 
 	err := apiClient.List(context.TODO(), nmStateConfigList, &goclient.ListOptions{})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list nmStateConfigs across all namespaces due to %s", err.Error())
 
@@ -194,7 +193,6 @@ func ListNmStateConfigs(apiClient *clients.Settings, namespace string) ([]*NmSta
 	}
 
 	err := apiClient.List(context.TODO(), nmStateConfigList, &goclient.ListOptions{Namespace: namespace})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list nmStateConfigs in namespace: %s due to %s",
 			namespace, err.Error())

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -541,7 +541,6 @@ func (bmc *BMC) SystemPowerCycle() error {
 			// Wait and get power state again.
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failure waiting for system's power state to be %v: %v", redfish.OffPowerState, err)
 
@@ -889,6 +888,7 @@ func (bmc *BMC) RunCLICommand(
 	var combinedOutput []byte
 
 	errCh := make(chan error)
+
 	go func() {
 		var err error
 		if combineOutput {
@@ -896,6 +896,7 @@ func (bmc *BMC) RunCLICommand(
 		} else {
 			err = sshSession.Run(cmd)
 		}
+
 		errCh <- err
 	}()
 

--- a/pkg/bmh/baremetalhost.go
+++ b/pkg/bmh/baremetalhost.go
@@ -352,7 +352,6 @@ func (builder *BmhBuilder) WithOptions(options ...AdditionalOptions) *BmhBuilder
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -453,7 +452,6 @@ func (builder *BmhBuilder) Delete() (*BmhBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete bmh: %w", err)
 	}
@@ -473,11 +471,11 @@ func (builder *BmhBuilder) Get() (*bmhv1alpha1.BareMetalHost, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	bmh := &bmhv1alpha1.BareMetalHost{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, bmh)
-
 	if err != nil {
 		return nil, err
 	}
@@ -495,6 +493,7 @@ func (builder *BmhBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -581,8 +580,8 @@ func (builder *BmhBuilder) WaitUntilInStatus(status bmhv1alpha1.ProvisioningStat
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				return false, nil
 			}
@@ -672,6 +671,7 @@ func (builder *BmhBuilder) WaitUntilAnnotationExists(annotation string, timeout 
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
@@ -687,7 +687,6 @@ func (builder *BmhBuilder) WaitUntilAnnotationExists(annotation string, timeout 
 
 			return true, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bmh/dataimage.go
+++ b/pkg/bmh/dataimage.go
@@ -89,7 +89,6 @@ func (builder *DataImageBuilder) Delete() (*DataImageBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("cannot delete dataimage: %w", err)
 	}
@@ -109,11 +108,11 @@ func (builder *DataImageBuilder) Get() (*bmhv1alpha1.DataImage, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	dataimage := &bmhv1alpha1.DataImage{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, dataimage)
-
 	if err != nil {
 		return nil, err
 	}
@@ -131,6 +130,7 @@ func (builder *DataImageBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/bmh/hfc.go
+++ b/pkg/bmh/hfc.go
@@ -81,11 +81,11 @@ func (builder *HFCBuilder) Get() (*bmhv1alpha1.HostFirmwareComponents, error) {
 		"Getting HostFirmwareComponents object %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	hostFirmwareComponents := &bmhv1alpha1.HostFirmwareComponents{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, hostFirmwareComponents)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"HostFirmwareComponents object %s does not exist in namespace %s",
@@ -107,6 +107,7 @@ func (builder *HFCBuilder) Exists() bool {
 		"Checking if HostFirmwareComponents %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/bmh/hfs.go
+++ b/pkg/bmh/hfs.go
@@ -81,11 +81,11 @@ func (builder *HFSBuilder) Get() (*bmhv1alpha1.HostFirmwareSettings, error) {
 		"Getting HostFirmwareSettings object %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	hostFirmwareSettings := &bmhv1alpha1.HostFirmwareSettings{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, hostFirmwareSettings)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"HostFirmwareSettings object %s does not exist in namespace %s",
@@ -107,6 +107,7 @@ func (builder *HFSBuilder) Exists() bool {
 		"Checking if HostFirmwareSettings %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/bmh/list.go
+++ b/pkg/bmh/list.go
@@ -114,7 +114,6 @@ func WaitForAllBareMetalHostsInGoodOperationalState(apiClient *clients.Settings,
 
 			return true, nil
 		})
-
 	if err == nil {
 		glog.V(100).Infof("All baremetalhosts were found in the good Operational State "+
 			"during defined timeout: %v", timeout)
@@ -139,8 +138,8 @@ func list(apiClient *clients.Settings, options goclient.ListOptions) ([]*BmhBuil
 	}
 
 	var bmhList bmhv1alpha1.BareMetalHostList
-	err = apiClient.List(context.TODO(), &bmhList, &options)
 
+	err = apiClient.List(context.TODO(), &bmhList, &options)
 	if err != nil {
 		glog.V(100).Infof("Failed to list bareMetalHosts due to %s", err.Error())
 

--- a/pkg/certificate/signingrequest.go
+++ b/pkg/certificate/signingrequest.go
@@ -76,10 +76,10 @@ func (builder *SigningRequestBuilder) Get() (*certificatesv1.CertificateSigningR
 	glog.V(100).Infof("Collecting CertificateSigningRequest object %s", builder.Definition.Name)
 
 	signingRequest := &certificatesv1.CertificateSigningRequest{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, signingRequest)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get CertificateSigningRequest object %s: %v", builder.Definition.Name, err)
 
@@ -98,6 +98,7 @@ func (builder *SigningRequestBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if CertificateSigningRequest %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/certificate/signingrequestlist.go
+++ b/pkg/certificate/signingrequestlist.go
@@ -47,8 +47,8 @@ func ListSigningRequests(
 	glog.V(100).Info(logMessage)
 
 	csrList := new(certificatesv1.CertificateSigningRequestList)
-	err = apiClient.List(context.TODO(), csrList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), csrList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list CertificateSigningRequests: %v", err)
 

--- a/pkg/cgu/cgu.go
+++ b/pkg/cgu/cgu.go
@@ -209,10 +209,10 @@ func (builder *CguBuilder) Get() (*v1alpha1.ClusterGroupUpgrade, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterGroupUpgrade := &v1alpha1.ClusterGroupUpgrade{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		goclient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		clusterGroupUpgrade)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"clusterGroupUpgrade object %s does not exist in namespace %s",
@@ -234,6 +234,7 @@ func (builder *CguBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -282,7 +283,6 @@ func (builder *CguBuilder) Delete() (*CguBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete cgu: %w", err)
 	}
@@ -301,7 +301,6 @@ func (builder *CguBuilder) Update(force bool) (*CguBuilder, error) {
 	glog.V(100).Infof("Updating the cgu object", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	} else if force {
@@ -394,8 +393,8 @@ func (builder *CguBuilder) WaitForCondition(expected metav1.Condition, timeout t
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Info("failed to get cgu %s/%s: %w", builder.Definition.Name, builder.Definition.Namespace, err)
 
@@ -463,6 +462,7 @@ func (builder *CguBuilder) WaitUntilClusterInState(cluster, state string, timeou
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
@@ -481,7 +481,6 @@ func (builder *CguBuilder) WaitUntilClusterInState(cluster, state string, timeou
 
 			return status.State == state, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}
@@ -515,6 +514,7 @@ func (builder *CguBuilder) WaitUntilBackupStarts(timeout time.Duration) (*CguBui
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(context.TODO(), 3*time.Second, timeout, true, func(context.Context) (bool, error) {
 		builder.Object, err = builder.Get()
 		if err != nil {
@@ -526,7 +526,6 @@ func (builder *CguBuilder) WaitUntilBackupStarts(timeout time.Duration) (*CguBui
 
 		return builder.Object.Status.Backup != nil, nil
 	})
-
 	if err == nil {
 		return builder, nil
 	}

--- a/pkg/cgu/cgulist.go
+++ b/pkg/cgu/cgulist.go
@@ -42,8 +42,8 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...client.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	cguList := &v1alpha1.ClusterGroupUpgradeList{}
-	err = apiClient.List(context.TODO(), cguList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), cguList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all CGUs in all namespaces due to %s", err.Error())
 

--- a/pkg/cgu/precachingconfig.go
+++ b/pkg/cgu/precachingconfig.go
@@ -130,6 +130,7 @@ func (builder *PreCachingConfigBuilder) Exists() bool {
 		"Checking if preCachingConfig %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -112,8 +112,8 @@ func New(kubeconfig string) *Settings {
 	clientSet.Config = config
 
 	clientSet.scheme = runtime.NewScheme()
-	err = SetScheme(clientSet.scheme)
 
+	err = SetScheme(clientSet.scheme)
 	if err != nil {
 		glog.V(100).Info("Error to load apiClient scheme")
 
@@ -123,7 +123,6 @@ func New(kubeconfig string) *Settings {
 	clientSet.Client, err = runtimeClient.New(config, runtimeClient.Options{
 		Scheme: clientSet.scheme,
 	})
-
 	if err != nil {
 		glog.V(100).Info("Error to create apiClient")
 

--- a/pkg/clusterlogging/clusterlogforwarder.go
+++ b/pkg/clusterlogging/clusterlogforwarder.go
@@ -236,11 +236,11 @@ func (builder *ClusterLogForwarderBuilder) Get() (*observabilityv1.ClusterLogFor
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterLogForwarder := &observabilityv1.ClusterLogForwarder{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, clusterLogForwarder)
-
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,6 @@ func (builder *ClusterLogForwarderBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete clusterlogforwarder: %w", err)
 	}
@@ -307,6 +306,7 @@ func (builder *ClusterLogForwarderBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -322,14 +322,12 @@ func (builder *ClusterLogForwarderBuilder) Update(force bool) (*ClusterLogForwar
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("clusterlogforwarder", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError(

--- a/pkg/clusterlogging/elasticsearch.go
+++ b/pkg/clusterlogging/elasticsearch.go
@@ -132,11 +132,11 @@ func (builder *ElasticsearchBuilder) Get() (*eskv1.Elasticsearch, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	elasticsearchObj := &eskv1.Elasticsearch{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, elasticsearchObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,6 @@ func (builder *ElasticsearchBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete elasticsearch: %w", err)
 	}
@@ -198,6 +197,7 @@ func (builder *ElasticsearchBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -213,7 +213,6 @@ func (builder *ElasticsearchBuilder) Update() (*ElasticsearchBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("elasticsearch", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/clusterlogging/lokistack.go
+++ b/pkg/clusterlogging/lokistack.go
@@ -136,11 +136,11 @@ func (builder *LokiStackBuilder) Get() (*lokiv1.LokiStack, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	lokiStackObj := &lokiv1.LokiStack{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, lokiStackObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,6 @@ func (builder *LokiStackBuilder) Delete() (*LokiStackBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete lokiStack: %w", err)
 	}
@@ -208,6 +207,7 @@ func (builder *LokiStackBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -223,7 +223,6 @@ func (builder *LokiStackBuilder) Update() (*LokiStackBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("lokiStack", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/clusteroperator/clusteroperator.go
+++ b/pkg/clusteroperator/clusteroperator.go
@@ -2,15 +2,12 @@ package clusteroperator
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/wait"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/golang/glog"
 	configv1 "github.com/openshift/api/config/v1"
@@ -80,10 +77,10 @@ func (builder *Builder) Get() (*configv1.ClusterOperator, error) {
 	glog.V(100).Infof("Getting existing clusterOperator with name %s from cluster", builder.Definition.Name)
 
 	clusterOperatorObj := &configv1.ClusterOperator{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, clusterOperatorObj)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get clusterOperator object %s from cluster due to: %w",
 			builder.Definition.Name, err)
@@ -103,6 +100,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if clusterOperator %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -169,7 +167,6 @@ func (builder *Builder) GetConditionReason(conditionType configv1.ClusterStatusC
 		builder.Definition.Name, conditionType)
 
 	err := builder.WaitUntilConditionTrue(conditionType, time.Second)
-
 	if err != nil {
 		return ""
 	}
@@ -207,8 +204,8 @@ func (builder *Builder) WaitUntilConditionTrue(
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				return false, nil
 			}

--- a/pkg/clusteroperator/list.go
+++ b/pkg/clusteroperator/list.go
@@ -30,7 +30,6 @@ func List(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*Builde
 	glog.V(100).Infof(logMessage)
 
 	coList, err := apiClient.ClusterOperators().List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list clusterOperators due to %s", err.Error())
 
@@ -60,7 +59,6 @@ func WaitForAllClusteroperatorsAvailable(
 
 	err := wait.PollUntilContextTimeout(context.TODO(), fiveScds, timeout, true, func(ctx context.Context) (bool, error) {
 		coList, err := List(apiClient, options...)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to list all clusterOperators due to %s", err.Error())
 
@@ -78,7 +76,6 @@ func WaitForAllClusteroperatorsAvailable(
 
 		return true, nil
 	})
-
 	if err == nil {
 		glog.V(100).Infof("All clusterOperators were found available before timeout: %v",
 			timeout)
@@ -117,7 +114,6 @@ func WaitForAllClusteroperatorsStopProgressing(
 
 		return true, nil
 	})
-
 	if err == nil {
 		glog.V(100).Infof("All clusterOperators stopped progressing before timeout: %v",
 			timeout)
@@ -151,8 +147,8 @@ func VerifyClusterOperatorsVersion(desiredVersion string, clusterOperatorList []
 
 	for _, operator := range clusterOperatorList {
 		glog.V(100).Infof("Checking %s clusterOperator version", operator.Definition.Name)
-		hasDesiredVersion, err := operator.HasDesiredVersion(desiredVersion)
 
+		hasDesiredVersion, err := operator.HasDesiredVersion(desiredVersion)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -76,8 +76,8 @@ func (builder *Builder) Get() (*configv1.ClusterVersion, error) {
 	glog.V(100).Infof("Getting ClusterVersion object %s", builder.Definition.Name)
 
 	clusterVersion := &configv1.ClusterVersion{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, clusterVersion)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, clusterVersion)
 	if err != nil {
 		glog.V(100).Infof("Failed to get ClusterVersion %s: %s", builder.Definition.Name, err)
 
@@ -96,6 +96,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if ClusterVersion %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -196,8 +197,8 @@ func (builder *Builder) WaitUntilConditionTrue(
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Infof("Failed to get the ClusterVersion with error %s", err)
 
@@ -238,8 +239,8 @@ func (builder *Builder) WaitUntilUpdateHistoryStateTrue(
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Infof("Failed to get the ClusterVersion with error %s", err)
 
@@ -307,7 +308,6 @@ func (builder *Builder) isStreamUpdate(version, updateVersion, stream string) (i
 	}
 
 	semVersion, semVersionError := semver.NewVersion(version)
-
 	if semVersionError != nil {
 		return false, fmt.Errorf("the version %s is invalid", version)
 	}

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -136,7 +136,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.ConfigMaps(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -157,6 +156,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.ConfigMaps(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -176,7 +176,6 @@ func (builder *Builder) Update() (*Builder, error) {
 
 	builder.Object, err = builder.apiClient.ConfigMaps(builder.Definition.Namespace).
 		Update(context.TODO(), builder.Definition, metav1.UpdateOptions{})
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("configmap", builder.Definition.Name, builder.Definition.Namespace))
@@ -221,7 +220,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/configmap/list.go
+++ b/pkg/configmap/list.go
@@ -41,7 +41,6 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	configmapList, err := apiClient.ConfigMaps(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list configmaps in the namespace %s due to %s", nsname, err.Error())
 
@@ -89,7 +88,6 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	configmapList, err := apiClient.ConfigMaps("").List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list configmaps in all namespaces due to %s", err.Error())
 

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -117,10 +117,10 @@ func (builder *Builder) Get() (*configv1.Console, error) {
 	glog.V(100).Infof("Getting Console object %s", builder.Definition.Name)
 
 	console := &configv1.Console{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, console)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get Console object %s: %v", builder.Definition.Name, err)
 
@@ -161,6 +161,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if console %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/console/consoleoperator.go
+++ b/pkg/console/consoleoperator.go
@@ -72,10 +72,10 @@ func (builder *ConsoleOperatorBuilder) Get() (*operatorv1.Console, error) {
 	glog.V(100).Infof("Getting existing consoleOperator with name %s from cluster", builder.Definition.Name)
 
 	consoleOperator := &operatorv1.Console{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, consoleOperator)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get consoleOperator object %s from cluster due to: %v",
 			builder.Definition.Name, err)
@@ -95,6 +95,7 @@ func (builder *ConsoleOperatorBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if consoleOperator %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -257,7 +257,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -297,6 +296,7 @@ func (builder *Builder) Update() (*Builder, error) {
 	glog.V(100).Infof("Updating daemonset %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -351,7 +351,6 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.apiClient.Get(
 				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
-
 			if err != nil {
 				return false, nil
 			}
@@ -375,7 +374,6 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 
 			return false, err
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -419,6 +417,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -441,7 +440,6 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 
 			builder.Object, err = builder.apiClient.Get(
 				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
-
 			if err != nil {
 				glog.V(100).Infof("Failed to get daemonset from cluster. Error is: '%s'", err.Error())
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -199,7 +199,6 @@ func (builder *Builder) WithSecondaryNetwork(networks []*multus.NetworkSelection
 	}
 
 	netAnnotation, err := json.Marshal(networks)
-
 	if err != nil {
 		builder.errorMsg = fmt.Sprintf("error to unmarshal networks annotation due to: %s", err.Error())
 
@@ -408,7 +407,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -448,6 +446,7 @@ func (builder *Builder) Update() (*Builder, error) {
 	glog.V(100).Infof("Updating deployment %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Deployments(builder.Definition.Namespace).Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -474,7 +473,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.Deployments(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -516,7 +514,6 @@ func (builder *Builder) DeleteGraceful(gracePeriod *int64) error {
 
 	err := builder.apiClient.Deployments(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{GracePeriodSeconds: gracePeriod})
-
 	if err != nil {
 		return err
 	}
@@ -566,9 +563,9 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
+
 			builder.Object, err = builder.apiClient.Deployments(builder.Definition.Namespace).Get(
 				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
-
 			if err != nil {
 				glog.V(100).Infof("Failed to get deployment from cluster. Error is: '%s'", err.Error())
 
@@ -621,6 +618,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Deployments(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 

--- a/pkg/deployment/list.go
+++ b/pkg/deployment/list.go
@@ -34,7 +34,6 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	deploymentList, err := apiClient.Deployments(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list deployments in the namespace %s due to %s", nsname, err.Error())
 
@@ -76,7 +75,6 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	deploymentList, err := apiClient.Deployments("").List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list deployments in all namespaces due to %s", err.Error())
 

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -72,8 +72,8 @@ func (builder *Builder) Get() (*configv1.DNS, error) {
 	glog.V(100).Infof("Getting DNS object %s", builder.Definition.Name)
 
 	dnsObject := &configv1.DNS{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, dnsObject)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, dnsObject)
 	if err != nil {
 		glog.V(100).Infof("Failed to get DNS %s: %s", builder.Definition.Name, err)
 
@@ -92,6 +92,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if DNS %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/egressip/egressip.go
+++ b/pkg/egressip/egressip.go
@@ -179,6 +179,7 @@ func (builder *EgressIPBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if egressIP %q exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -197,7 +198,6 @@ func (builder *EgressIPBuilder) Get() (*egressipv1.EgressIP, error) {
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, egrIP)
-
 	if err != nil {
 		glog.V(100).Infof("Error retrieving egressIP: %v", err)
 
@@ -219,7 +219,6 @@ func (builder *EgressIPBuilder) Create() (*EgressIPBuilder, error) {
 
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			glog.V(100).Infof("Created egressIP %q", builder.Definition.Name)
 
@@ -249,7 +248,6 @@ func (builder *EgressIPBuilder) Delete() (*EgressIPBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof("Error deleting egressIP: %v", err)
 
@@ -272,7 +270,6 @@ func (builder *EgressIPBuilder) Update() (*EgressIPBuilder, error) {
 	glog.V(100).Infof("Updating egressIP %s", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof("Error updating egressIP: %v", err)
 

--- a/pkg/egressservice/egressservice.go
+++ b/pkg/egressservice/egressservice.go
@@ -194,6 +194,7 @@ func (builder *EgressServiceBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -214,7 +215,6 @@ func (builder *EgressServiceBuilder) Get() (*egresssvcv1.EgressService, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, egrSvc)
-
 	if err != nil {
 		glog.V(100).Infof("Error retrieving EgressService: %v", err)
 
@@ -237,7 +237,6 @@ func (builder *EgressServiceBuilder) Create() (*EgressServiceBuilder, error) {
 
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			glog.V(100).Infof("Created EgressServcice %q in namespace %q",
 				builder.Definition.Name, builder.Definition.Namespace)
@@ -270,7 +269,6 @@ func (builder *EgressServiceBuilder) Delete() (*EgressServiceBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof("Error deleting EgressService: %v", err)
 
@@ -295,7 +293,6 @@ func (builder *EgressServiceBuilder) Update() (*EgressServiceBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof("Error updating EgressService: %v", err)
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -70,6 +70,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if Event %s exists", builder.Object.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Get(context.TODO(),
 		builder.Object.Name, metaV1.GetOptions{})
 

--- a/pkg/events/list.go
+++ b/pkg/events/list.go
@@ -35,7 +35,6 @@ func List(
 	glog.V(100).Infof(logMessage)
 
 	eventList, err := apiClient.Events(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list Events in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/hive/clusterdeployment.go
+++ b/pkg/hive/clusterdeployment.go
@@ -207,11 +207,11 @@ func (builder *ClusterDeploymentBuilder) Get() (*hiveV1.ClusterDeployment, error
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterDeployment := &hiveV1.ClusterDeployment{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, clusterDeployment)
-
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +299,6 @@ func (builder *ClusterDeploymentBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -323,14 +322,12 @@ func (builder *ClusterDeploymentBuilder) Update(force bool) (*ClusterDeploymentB
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("clusterdeployment", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("clusterdeployment", builder.Definition.Name, builder.Definition.Namespace))
@@ -368,7 +365,6 @@ func (builder *ClusterDeploymentBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete clusterdeployment: %w", err)
 	}
@@ -388,6 +384,7 @@ func (builder *ClusterDeploymentBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/hive/clusterdeploymentlist.go
+++ b/pkg/hive/clusterdeploymentlist.go
@@ -44,8 +44,8 @@ func ListClusterDeploymentsInAllNamespaces(
 	glog.V(100).Infof(logMessage)
 
 	clusterDeployments := new(hiveV1.ClusterDeploymentList)
-	err = apiClient.List(context.TODO(), clusterDeployments, &passedOptions)
 
+	err = apiClient.List(context.TODO(), clusterDeployments, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all clusterDeployments due to %s", err.Error())
 

--- a/pkg/hive/clusterimageset.go
+++ b/pkg/hive/clusterimageset.go
@@ -125,10 +125,10 @@ func (builder *ClusterImageSetBuilder) Get() (*hiveV1.ClusterImageSet, error) {
 	glog.V(100).Infof("Getting clusterimageset %s", builder.Definition.Name)
 
 	clusterimageset := &hiveV1.ClusterImageSet{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, clusterimageset)
-
 	if err != nil {
 		return nil, err
 	}
@@ -164,14 +164,12 @@ func (builder *ClusterImageSetBuilder) Update(force bool) (*ClusterImageSetBuild
 	glog.V(100).Infof("Updating clusterimageset %s", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("clusterimageset", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("clusterimageset", builder.Definition.Name, builder.Definition.Namespace))
@@ -207,7 +205,6 @@ func (builder *ClusterImageSetBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete clusterimageset: %w", err)
 	}
@@ -228,6 +225,7 @@ func (builder *ClusterImageSetBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if clusterimageset %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -267,7 +265,6 @@ func (builder *ClusterImageSetBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/hive/config.go
+++ b/pkg/hive/config.go
@@ -114,10 +114,10 @@ func (builder *ConfigBuilder) Get() (*hiveV1.HiveConfig, error) {
 	glog.V(100).Infof("Getting HiveConfig %s", builder.Definition.Name)
 
 	HiveConfig := &hiveV1.HiveConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeClient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, HiveConfig)
-
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,6 @@ func (builder *ConfigBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete hiveconfig: %w", err)
 	}
@@ -177,6 +176,7 @@ func (builder *ConfigBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if hiveconfig %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -193,7 +193,6 @@ func (builder *ConfigBuilder) WithOptions(options ...ConfigAdditionalOptions) *C
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/ibgu/ibgu.go
+++ b/pkg/ibgu/ibgu.go
@@ -274,7 +274,6 @@ func (builder *IbguBuilder) Get() (*v1alpha1.ImageBasedGroupUpgrade, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, imagebasedgroupupgrade)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get imagebasedgroupupgrade %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -295,6 +294,7 @@ func (builder *IbguBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -336,7 +336,6 @@ func (builder *IbguBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Object)
-
 	if err != nil {
 		return err
 	}
@@ -462,8 +461,8 @@ func (builder *IbguBuilder) WaitForCondition(expected metav1.Condition, timeout 
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Info("failed to get ibgu %s/%s: %w", builder.Definition.Namespace, builder.Definition.Name, err)
 

--- a/pkg/ibi/imageclusterinstall.go
+++ b/pkg/ibi/imageclusterinstall.go
@@ -317,11 +317,11 @@ func (builder *ImageClusterInstallBuilder) Get() (*ibiv1alpha1.ImageClusterInsta
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	imageClusterInstall := &ibiv1alpha1.ImageClusterInstall{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, imageClusterInstall)
-
 	if err != nil {
 		return nil, err
 	}
@@ -366,14 +366,12 @@ func (builder *ImageClusterInstallBuilder) Update(force bool) (*ImageClusterInst
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("imageclusterinstall", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("imageclusterinstall", builder.Definition.Name, builder.Definition.Namespace))
@@ -406,7 +404,6 @@ func (builder *ImageClusterInstallBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete imageclusterinstall: %w", err)
 	}
@@ -426,6 +423,7 @@ func (builder *ImageClusterInstallBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/icsp/icsp.go
+++ b/pkg/icsp/icsp.go
@@ -142,8 +142,8 @@ func (builder *ICSPBuilder) Get() (*v1alpha1.ImageContentSourcePolicy, error) {
 	glog.V(100).Infof("Getting ImageContentSourcePolicy object %s", builder.Definition.Name)
 
 	icsp := &v1alpha1.ImageContentSourcePolicy{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, icsp)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, icsp)
 	if err != nil {
 		glog.V(100).Infof("ImageContentSourcePolicy object %s does not exist", builder.Definition.Name)
 
@@ -162,6 +162,7 @@ func (builder *ICSPBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if ImageContentSourcePolicy %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -228,8 +229,8 @@ func (builder *ICSPBuilder) Update() (*ICSPBuilder, error) {
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		glog.V(100).Infof("Failed to update ImageContentSourcePolicy %s", builder.Definition.Name)
 
@@ -284,7 +285,6 @@ func (builder *ICSPBuilder) WithOptions(options ...AdditionalOptions) *ICSPBuild
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/idms/idms.go
+++ b/pkg/idms/idms.go
@@ -136,10 +136,10 @@ func (builder *Builder) Get() (*configv1.ImageDigestMirrorSet, error) {
 		builder.Definition.Name)
 
 	imageDigestMirrorSet := &configv1.ImageDigestMirrorSet{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeClient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, imageDigestMirrorSet)
-
 	if err != nil {
 		return nil, err
 	}
@@ -184,14 +184,12 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("imagedigestmirrorset", builder.Definition.Name))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("imagedigestmirrorset", builder.Definition.Name))
@@ -227,7 +225,6 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete imagedigestmirrorset: %w", err)
 	}
@@ -247,6 +244,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/idms/list.go
+++ b/pkg/idms/list.go
@@ -45,8 +45,8 @@ func ListImageDigestMirrorSets(
 	glog.V(100).Infof(logMessage)
 
 	imageDigestMirrorSets := new(configv1.ImageDigestMirrorSetList)
-	err := apiClient.List(context.TODO(), imageDigestMirrorSets, &passedOptions)
 
+	err := apiClient.List(context.TODO(), imageDigestMirrorSets, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all imageDigestMirrorSets due to %s", err.Error())
 

--- a/pkg/imageregistry/imageregistry.go
+++ b/pkg/imageregistry/imageregistry.go
@@ -84,10 +84,10 @@ func (builder *Builder) Get() (*imageregistryv1.Config, error) {
 	glog.V(100).Infof("Getting existing imageRegistry with name %s from cluster", builder.Definition.Name)
 
 	imageRegistry := &imageregistryv1.Config{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, imageRegistry)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get ImageRegistry object %s: %v", builder.Definition.Name, err)
 
@@ -106,6 +106,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if imageRegistry %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -207,6 +208,7 @@ func (builder *Builder) WaitForCondition(
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
@@ -236,7 +238,6 @@ func (builder *Builder) WaitForCondition(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imagestream/imagestream.go
+++ b/pkg/imagestream/imagestream.go
@@ -87,11 +87,11 @@ func (builder *Builder) Get() (*imagev1.ImageStream, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	imageStreamObj := &imagev1.ImageStream{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, imageStreamObj)
-
 	if err != nil {
 		glog.V(100).Infof("imageStream object %s does not exist in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)
@@ -112,6 +112,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -73,8 +73,8 @@ func (builder *Builder) Get() (*configv1.Infrastructure, error) {
 	glog.V(100).Infof("Getting Infrastructure object %s", builder.Definition.Name)
 
 	infrastructure := &configv1.Infrastructure{}
-	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, infrastructure)
 
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, infrastructure)
 	if err != nil {
 		glog.V(100).Infof("Failed to get Infrastructure object %s: %v", builder.Definition.Name, err)
 
@@ -93,6 +93,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if infrastructure %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/ingress/ingresscontroller.go
+++ b/pkg/ingress/ingresscontroller.go
@@ -68,11 +68,11 @@ func (builder *Builder) Get() (*operatorv1.IngressController, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	lvs := &operatorv1.IngressController{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, lvs)
-
 	if err != nil {
 		return nil, err
 	}
@@ -90,6 +90,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -113,7 +114,6 @@ func (builder *Builder) Update() (*Builder, error) {
 	builder.Definition.ResourceVersion = ""
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return nil, fmt.Errorf("cannot update ingresscontroller: %w", err)
 	}
@@ -133,7 +133,6 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -158,7 +157,6 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete ingresscontroller: %w", err)
 	}

--- a/pkg/keda/kedacontroller.go
+++ b/pkg/keda/kedacontroller.go
@@ -132,11 +132,11 @@ func (builder *ControllerBuilder) Get() (*kedav1alpha1.KedaController, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	kedaObj := &kedav1alpha1.KedaController{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, kedaObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,6 @@ func (builder *ControllerBuilder) Delete() (*ControllerBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete kedaController: %w", err)
 	}
@@ -203,6 +202,7 @@ func (builder *ControllerBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -218,7 +218,6 @@ func (builder *ControllerBuilder) Update() (*ControllerBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("kedaController", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/keda/scaleobject.go
+++ b/pkg/keda/scaleobject.go
@@ -135,11 +135,11 @@ func (builder *ScaledObjectBuilder) Get() (*kedav2v1alpha1.ScaledObject, error) 
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	scaleObjectObj := &kedav2v1alpha1.ScaledObject{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, scaleObjectObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,6 @@ func (builder *ScaledObjectBuilder) Delete() (*ScaledObjectBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete scaledObject: %w", err)
 	}
@@ -207,6 +206,7 @@ func (builder *ScaledObjectBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -222,7 +222,6 @@ func (builder *ScaledObjectBuilder) Update() (*ScaledObjectBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("scaledObject", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/keda/triggerauthentication.go
+++ b/pkg/keda/triggerauthentication.go
@@ -136,11 +136,11 @@ func (builder *TriggerAuthenticationBuilder) Get() (*kedav2v1alpha1.TriggerAuthe
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	triggerAuthenticationObj := &kedav2v1alpha1.TriggerAuthentication{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, triggerAuthenticationObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,6 @@ func (builder *TriggerAuthenticationBuilder) Delete() (*TriggerAuthenticationBui
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete triggerAuthentication: %w", err)
 	}
@@ -208,6 +207,7 @@ func (builder *TriggerAuthenticationBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -223,7 +223,6 @@ func (builder *TriggerAuthenticationBuilder) Update() (*TriggerAuthenticationBui
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("triggerAuthentication", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/kmm/containers.go
+++ b/pkg/kmm/containers.go
@@ -157,7 +157,6 @@ func (builder *ModuleLoaderContainerBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/kmm/kernelmapping.go
+++ b/pkg/kmm/kernelmapping.go
@@ -288,7 +288,6 @@ func (builder *KernelMappingBuilder) WithOptions(options ...KernelMappingAdditio
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/kmm/managedclustermodule.go
+++ b/pkg/kmm/managedclustermodule.go
@@ -134,7 +134,6 @@ func (builder *ManagedClusterModuleBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -228,7 +227,6 @@ func (builder *ManagedClusterModuleBuilder) Update() (*ManagedClusterModuleBuild
 		builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -246,6 +244,7 @@ func (builder *ManagedClusterModuleBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -269,7 +268,6 @@ func (builder *ManagedClusterModuleBuilder) Delete() (*ManagedClusterModuleBuild
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, err
 	}
@@ -294,7 +292,6 @@ func (builder *ManagedClusterModuleBuilder) Get() (*mcmV1Beta1.ManagedClusterMod
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, mcm)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kmm/module.go
+++ b/pkg/kmm/module.go
@@ -286,7 +286,6 @@ func (builder *ModuleBuilder) WithOptions(options ...ModuleAdditionalOptions) *M
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -361,7 +360,6 @@ func (builder *ModuleBuilder) Create() (*ModuleBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -381,7 +379,6 @@ func (builder *ModuleBuilder) Update() (*ModuleBuilder, error) {
 		builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -399,6 +396,7 @@ func (builder *ModuleBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -422,7 +420,6 @@ func (builder *ModuleBuilder) Delete() (*ModuleBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, err
 	}
@@ -447,7 +444,6 @@ func (builder *ModuleBuilder) Get() (*moduleV1Beta1.Module, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, module)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kmm/preflightvalidation.go
+++ b/pkg/kmm/preflightvalidation.go
@@ -123,7 +123,6 @@ func (builder *PreflightValidationBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -218,7 +217,6 @@ func (builder *PreflightValidationBuilder) Update() (*PreflightValidationBuilder
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -236,6 +234,7 @@ func (builder *PreflightValidationBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -260,7 +259,6 @@ func (builder *PreflightValidationBuilder) Delete() (*PreflightValidationBuilder
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("cannot delete preflightvalidation: %w", err)
 	}
@@ -286,7 +284,6 @@ func (builder *PreflightValidationBuilder) Get() (*kmmv1beta2.PreflightValidatio
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, preflightvalidation)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kmm/preflightvalidationocp.go
+++ b/pkg/kmm/preflightvalidationocp.go
@@ -142,7 +142,6 @@ func (builder *PreflightValidationOCPBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -237,7 +236,6 @@ func (builder *PreflightValidationOCPBuilder) Update() (*PreflightValidationOCPB
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -255,6 +253,7 @@ func (builder *PreflightValidationOCPBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -279,7 +278,6 @@ func (builder *PreflightValidationOCPBuilder) Delete() (*PreflightValidationOCPB
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("cannot delete preflightvalidationocp: %w", err)
 	}
@@ -305,7 +303,6 @@ func (builder *PreflightValidationOCPBuilder) Get() (*kmmv1beta2.PreflightValida
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, preflightvalidationocp)
-
 	if err != nil {
 		glog.V(100).Infof("Preflightvalidationocp object %s does not exist in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)

--- a/pkg/lca/imagebasedupgrade.go
+++ b/pkg/lca/imagebasedupgrade.go
@@ -2,23 +2,19 @@ package lca
 
 import (
 	"context"
-	"time"
-
-	"k8s.io/utils/strings/slices"
-
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/golang/glog"
-
 	"fmt"
-
-	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/strings/slices"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/golang/glog"
+	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
 )
 
 const (
@@ -58,7 +54,6 @@ func (builder *ImageBasedUpgradeBuilder) WithOptions(options ...AdditionalOption
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -145,7 +140,6 @@ func (builder *ImageBasedUpgradeBuilder) Update() (*ImageBasedUpgradeBuilder, er
 
 				return false, nil
 			})
-
 		if err == nil {
 			builder.Definition = builder.Object
 		}
@@ -175,7 +169,6 @@ func (builder *ImageBasedUpgradeBuilder) Delete() (*ImageBasedUpgradeBuilder, er
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete imagebasedupgrade: %w", err)
 	}
@@ -195,10 +188,10 @@ func (builder *ImageBasedUpgradeBuilder) Get() (*lcav1.ImageBasedUpgrade, error)
 		builder.Definition.Name)
 
 	imagebasedupgrade := &lcav1.ImageBasedUpgrade{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, imagebasedupgrade)
-
 	if err != nil {
 		return nil, err
 	}
@@ -216,6 +209,7 @@ func (builder *ImageBasedUpgradeBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -393,10 +387,10 @@ func (builder *ImageBasedUpgradeBuilder) WaitUntilStageComplete(stage string) (*
 
 	// Polls periodically to determine if imagebasedupgrade is in desired state.
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second*3, time.Minute*30, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
@@ -434,7 +428,6 @@ func (builder *ImageBasedUpgradeBuilder) WaitUntilStageComplete(stage string) (*
 
 			return false, nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}

--- a/pkg/lca/seedgenerator.go
+++ b/pkg/lca/seedgenerator.go
@@ -84,7 +84,6 @@ func (builder *SeedGeneratorBuilder) WithOptions(options ...SeedGeneratorAdditio
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -175,7 +174,6 @@ func (builder *SeedGeneratorBuilder) Delete() (*SeedGeneratorBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete seedgenerator: %w", err)
 	}
@@ -195,10 +193,10 @@ func (builder *SeedGeneratorBuilder) Get() (*lcasgv1.SeedGenerator, error) {
 		builder.Definition.Name)
 
 	seedgenerator := &lcasgv1.SeedGenerator{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, seedgenerator)
-
 	if err != nil {
 		return nil, err
 	}
@@ -216,6 +214,7 @@ func (builder *SeedGeneratorBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -283,10 +282,10 @@ func (builder *SeedGeneratorBuilder) WaitUntilComplete(timeout time.Duration) (*
 
 	// Polls periodically to determine if seedgenerator is in desired state.
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second*3, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
@@ -300,7 +299,6 @@ func (builder *SeedGeneratorBuilder) WaitUntilComplete(timeout time.Duration) (*
 
 			return false, nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}

--- a/pkg/lca/seedgenerator_test.go
+++ b/pkg/lca/seedgenerator_test.go
@@ -328,6 +328,7 @@ func TestSeedGeneratorWaitUntilComplete(t *testing.T) {
 		testSeedGenetator.Status = testCase.status
 
 		var runtimeObjects []runtime.Object
+
 		runtimeObjects = append(runtimeObjects, testSeedGenetator)
 
 		testSeedGeneratorBuilder := buildValidSeedGeneratorBuilder(

--- a/pkg/lso/localvolumediscovery.go
+++ b/pkg/lso/localvolumediscovery.go
@@ -139,11 +139,11 @@ func (builder *LocalVolumeDiscoveryBuilder) Get() (*lsov1alpha1.LocalVolumeDisco
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	lvd := &lsov1alpha1.LocalVolumeDiscovery{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, lvd)
-
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,6 @@ func (builder *LocalVolumeDiscoveryBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete localVolumeDiscovery %s from namespace %s: %w",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -209,6 +208,7 @@ func (builder *LocalVolumeDiscoveryBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -228,7 +228,6 @@ func (builder *LocalVolumeDiscoveryBuilder) IsDiscovering(timeout time.Duration)
 			var err error
 
 			phase, err := builder.GetPhase()
-
 			if err != nil {
 				glog.V(100).Infof("failed to get phase value for localVolumeDiscovery %s in namespace %s due to %w",
 					builder.Definition.Name, builder.Definition.Namespace, err)
@@ -238,7 +237,6 @@ func (builder *LocalVolumeDiscoveryBuilder) IsDiscovering(timeout time.Duration)
 
 			return phase == "Discovering", nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("localVolumeDiscovery %s in namespace %s is found not in the discovering state; %w",
 			builder.Definition.Name, builder.Definition.Namespace, err)

--- a/pkg/lso/localvolumeset.go
+++ b/pkg/lso/localvolumeset.go
@@ -136,11 +136,11 @@ func (builder *LocalVolumeSetBuilder) Get() (*lsov1alpha1.LocalVolumeSet, error)
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	lvs := &lsov1alpha1.LocalVolumeSet{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, lvs)
-
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,6 @@ func (builder *LocalVolumeSetBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete localVolumeSet: %w", err)
 	}
@@ -206,6 +205,7 @@ func (builder *LocalVolumeSetBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -229,7 +229,6 @@ func (builder *LocalVolumeSetBuilder) Update() (*LocalVolumeSetBuilder, error) {
 	builder.Definition.ResourceVersion = ""
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("localVolumeSet", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/machine/machineset.go
+++ b/pkg/machine/machineset.go
@@ -57,7 +57,6 @@ func NewSetBuilderFromCopy(
 	}
 
 	newSetBuilder, err := createNewWorkerMachineSetFromCopy(apiClient, nsName, instanceType, workerLabel, replicas)
-
 	if err != nil {
 		glog.V(100).Infof("Error initializing MachineSet from copy: %s", err.Error())
 
@@ -69,7 +68,6 @@ func NewSetBuilderFromCopy(
 	builder.Definition = newSetBuilder.Definition
 
 	err = builder.getPublicCloudKind()
-
 	if err != nil {
 		builder.errorMsg = fmt.Sprintf("error getting the public cloud kind: %v", err.Error())
 
@@ -79,7 +77,6 @@ func NewSetBuilderFromCopy(
 	glog.V(100).Infof("Updating copied MachineSet provider instanceType to: %s", instanceType)
 
 	err = builder.ChangeCloudProviderInstanceType(instanceType)
-
 	if err != nil {
 		builder.errorMsg = fmt.Sprintf("error changing the instanceType: %v", err.Error())
 
@@ -175,9 +172,9 @@ func (builder *SetBuilder) Exists() bool {
 		builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.MachineSets(builder.Definition.Namespace).Get(context.TODO(),
 		builder.Definition.Name, metav1.GetOptions{})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to collect MachineSet object due to %s", err.Error())
 	}
@@ -221,7 +218,6 @@ func (builder *SetBuilder) Delete() error {
 
 	err := builder.apiClient.MachineSets(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return fmt.Errorf("cannot delete MachineSet: %w", err)
 	}
@@ -238,7 +234,6 @@ func WaitForMachineSetReady(
 	return wait.PollUntilContextTimeout(
 		context.TODO(), 30*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			machineSetPulled, err := PullSet(apiClient, namespace, machineSetName)
-
 			if err != nil {
 				glog.V(100).Infof("MachineSet pull from cluster error: %v\n", err)
 
@@ -274,7 +269,6 @@ func (builder *SetBuilder) ChangeCloudProviderInstanceType(instanceType string) 
 		glog.V(100).Infof("Updating ProviderSpec InstanceType param for AWS public cloud")
 
 		err := builder.AWSChangeProviderInstanceType(instanceType)
-
 		if err != nil {
 			return fmt.Errorf("error from func AWSChangeProviderInstanceType(instanceType): %w", err)
 		}
@@ -284,7 +278,6 @@ func (builder *SetBuilder) ChangeCloudProviderInstanceType(instanceType string) 
 			"GCP public cloud")
 
 		err := builder.GCPChangeProviderMachineType(instanceType)
-
 		if err != nil {
 			return fmt.Errorf("error from func GCPChangeProviderMachineType(instanceType): %w", err)
 		}
@@ -293,7 +286,6 @@ func (builder *SetBuilder) ChangeCloudProviderInstanceType(instanceType string) 
 		glog.V(100).Infof("Updating ProviderSpec VMSize param for Azure public cloud")
 
 		err := builder.AzureChangeProviderVMSize(instanceType)
-
 		if err != nil {
 			return fmt.Errorf("error from func AzureChangeProviderVMSize(instanceType): %w", err)
 		}
@@ -318,7 +310,6 @@ func (builder *SetBuilder) AWSChangeProviderInstanceType(instanceType string) er
 	}
 
 	byteArray, err := json.Marshal(builder.Definition.Spec.Template.Spec.ProviderSpec.Value)
-
 	if err != nil {
 		return fmt.Errorf("error marshalling machineSet providerSpec.Value into byte array: %w", err)
 	}
@@ -327,8 +318,8 @@ func (builder *SetBuilder) AWSChangeProviderInstanceType(instanceType string) er
 		instanceType)
 
 	var AWSProviderSpecObject *machinev1beta1.AWSMachineProviderConfig
-	err = json.Unmarshal(byteArray, &AWSProviderSpecObject)
 
+	err = json.Unmarshal(byteArray, &AWSProviderSpecObject)
 	if err != nil {
 		glog.V(100).Infof("error unmarshalling byte array into AWSMachineProviderConfig object: %v", err)
 
@@ -340,7 +331,6 @@ func (builder *SetBuilder) AWSChangeProviderInstanceType(instanceType string) er
 	AWSProviderSpecObject.InstanceType = instanceType
 
 	byteArrayAWS, err := json.Marshal(AWSProviderSpecObject)
-
 	if err != nil {
 		glog.V(100).Infof("error marshalling AWSMachineProviderConfig object into byte array: %v", err)
 
@@ -348,7 +338,6 @@ func (builder *SetBuilder) AWSChangeProviderInstanceType(instanceType string) er
 	}
 
 	err = json.Unmarshal(byteArrayAWS, builder.Definition.Spec.Template.Spec.ProviderSpec.Value)
-
 	if err != nil {
 		glog.V(100).Infof("error unmarshalling AWSMachineProviderConfig byte array into "+
 			"ProviderSpec.Value object: %v", err)
@@ -370,7 +359,6 @@ func (builder *SetBuilder) GCPChangeProviderMachineType(machineType string) erro
 	}
 
 	byteArray, err := json.Marshal(builder.Definition.Spec.Template.Spec.ProviderSpec.Value)
-
 	if err != nil {
 		return fmt.Errorf("error marshalling machineSet providerSpec.Value into byte array: %w", err)
 	}
@@ -378,8 +366,8 @@ func (builder *SetBuilder) GCPChangeProviderMachineType(machineType string) erro
 	glog.V(100).Infof("Updating ProviderSpec MachineType param '%s' for GCP public cloud", machineType)
 
 	var GCPProviderSpecObject *machinev1beta1.GCPMachineProviderSpec
-	err = json.Unmarshal(byteArray, &GCPProviderSpecObject)
 
+	err = json.Unmarshal(byteArray, &GCPProviderSpecObject)
 	if err != nil {
 		glog.V(100).Infof("error unmarshalling byte array into GCPMachineProviderSpec object: %v", err)
 
@@ -391,7 +379,6 @@ func (builder *SetBuilder) GCPChangeProviderMachineType(machineType string) erro
 	GCPProviderSpecObject.MachineType = machineType
 
 	byteArrayGCP, err := json.Marshal(GCPProviderSpecObject)
-
 	if err != nil {
 		glog.V(100).Infof("error marshalling GCPMachineProviderSpec object into byte array: %v", err)
 
@@ -399,7 +386,6 @@ func (builder *SetBuilder) GCPChangeProviderMachineType(machineType string) erro
 	}
 
 	err = json.Unmarshal(byteArrayGCP, builder.Definition.Spec.Template.Spec.ProviderSpec.Value)
-
 	if err != nil {
 		glog.V(100).Infof("error unmarshalling ProviderSpec byte array into ProviderSpec.Value: %v", err)
 
@@ -420,7 +406,6 @@ func (builder *SetBuilder) AzureChangeProviderVMSize(vmSize string) error {
 	}
 
 	byteArray, err := json.Marshal(builder.Definition.Spec.Template.Spec.ProviderSpec.Value)
-
 	if err != nil {
 		return fmt.Errorf("error marshalling machineSet providerSpec.Value into byte array: %w", err)
 	}
@@ -429,8 +414,8 @@ func (builder *SetBuilder) AzureChangeProviderVMSize(vmSize string) error {
 		vmSize)
 
 	var AzureProviderSpecObject *machinev1beta1.AzureMachineProviderSpec
-	err = json.Unmarshal(byteArray, &AzureProviderSpecObject)
 
+	err = json.Unmarshal(byteArray, &AzureProviderSpecObject)
 	if err != nil {
 		glog.V(100).Infof("error unmarshalling byte array into AzureMachineProviderSpec object: %v", err)
 
@@ -442,7 +427,6 @@ func (builder *SetBuilder) AzureChangeProviderVMSize(vmSize string) error {
 	AzureProviderSpecObject.VMSize = vmSize
 
 	byteArrayAzure, err := json.Marshal(AzureProviderSpecObject)
-
 	if err != nil {
 		glog.V(100).Infof("error marshalling AzureMachineProviderSpec object into byte array: %v", err)
 
@@ -450,7 +434,6 @@ func (builder *SetBuilder) AzureChangeProviderVMSize(vmSize string) error {
 	}
 
 	err = json.Unmarshal(byteArrayAzure, builder.Definition.Spec.Template.Spec.ProviderSpec.Value)
-
 	if err != nil {
 		glog.V(100).Infof("error unmarshalling AzureMachineProviderSpec byte array into "+
 			"ProviderSpec.Value object: %v", err)
@@ -469,7 +452,6 @@ func createNewWorkerMachineSetFromCopy(
 	workerLabel string,
 	replicas int32) (*SetBuilder, error) {
 	workerSetBuilders, err := ListWorkerMachineSets(apiClient, namespace, workerLabel)
-
 	if err != nil {
 		return nil, fmt.Errorf("could not list worker MachineSets: %w", err)
 	}
@@ -531,7 +513,6 @@ func (builder *SetBuilder) getPublicCloudKind() error {
 
 	// Value field is of type *runtime.RawExtension
 	byteArray, err := json.Marshal(builder.Definition.Spec.Template.Spec.ProviderSpec.Value)
-
 	if err != nil {
 		builder.errorMsg = fmt.Sprintf("error determining public cloud kind: %v", err)
 
@@ -539,7 +520,6 @@ func (builder *SetBuilder) getPublicCloudKind() error {
 	}
 
 	err = json.Unmarshal(byteArray, &providerSpecMap)
-
 	if err != nil {
 		builder.errorMsg = fmt.Sprintf("error determining public cloud kind: %v", err)
 

--- a/pkg/machine/machinesetlist.go
+++ b/pkg/machine/machinesetlist.go
@@ -44,7 +44,6 @@ func ListWorkerMachineSets(
 	glog.V(100).Infof(logMessage)
 
 	machineSetList, err := apiClient.MachineSets(namespace).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list MachineSets in the namespace %s due to %s",
 			namespace, err.Error())

--- a/pkg/mco/kubeletconfig.go
+++ b/pkg/mco/kubeletconfig.go
@@ -120,8 +120,8 @@ func (builder *KubeletConfigBuilder) Get() (*mcv1.KubeletConfig, error) {
 	glog.V(100).Infof("Getting KubeletConfig object %s", builder.Definition.Name)
 
 	kubeletConfig := &mcv1.KubeletConfig{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, kubeletConfig)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, kubeletConfig)
 	if err != nil {
 		glog.V(100).Infof("KubeletConfig object %s does not exist", builder.Definition.Name)
 
@@ -185,6 +185,7 @@ func (builder *KubeletConfigBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if the kubeletconfig object %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -271,7 +272,6 @@ func (builder *KubeletConfigBuilder) WithOptions(options ...AdditionalOptions) *
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/mco/machineconfig.go
+++ b/pkg/mco/machineconfig.go
@@ -117,8 +117,8 @@ func (builder *MCBuilder) Get() (*mcv1.MachineConfig, error) {
 	glog.V(100).Infof("Getting MachineConfig object %s", builder.Definition.Name)
 
 	machineConfig := &mcv1.MachineConfig{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, machineConfig)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, machineConfig)
 	if err != nil {
 		glog.V(100).Infof("MachineConfig object %s does not exist", builder.Definition.Name)
 
@@ -198,6 +198,7 @@ func (builder *MCBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if the MachineConfig object %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -239,7 +240,6 @@ func (builder *MCBuilder) WithOptions(options ...MCAdditionalOptions) *MCBuilder
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/mco/machineconfiglist.go
+++ b/pkg/mco/machineconfiglist.go
@@ -42,8 +42,8 @@ func ListMC(apiClient *clients.Settings, options ...runtimeclient.ListOptions) (
 	glog.V(100).Infof(logMessage)
 
 	mcList := new(mcv1.MachineConfigList)
-	err = apiClient.List(context.TODO(), mcList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), mcList, &passedOptions)
 	if err != nil {
 		glog.V(100).Info("Failed to list MC objects due to %s", err.Error())
 

--- a/pkg/mco/mcp.go
+++ b/pkg/mco/mcp.go
@@ -125,8 +125,8 @@ func (builder *MCPBuilder) Get() (*mcv1.MachineConfigPool, error) {
 	glog.V(100).Infof("Getting MachineConfigPool object %s", builder.Definition.Name)
 
 	machineConfigPool := &mcv1.MachineConfigPool{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, machineConfigPool)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, machineConfigPool)
 	if err != nil {
 		glog.V(100).Infof("MachineConfigPool object %s does not exist", builder.Definition.Name)
 
@@ -193,6 +193,7 @@ func (builder *MCPBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -284,7 +285,6 @@ func (builder *MCPBuilder) WaitForUpdate(timeout time.Duration) error {
 
 					return false, nil
 				})
-
 			if err != nil {
 				return err
 			}
@@ -371,7 +371,6 @@ func (builder *MCPBuilder) WithOptions(options ...MCPAdditionalOptions) *MCPBuil
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/mco/mcplist.go
+++ b/pkg/mco/mcplist.go
@@ -45,8 +45,8 @@ func ListMCP(apiClient *clients.Settings, options ...runtimeclient.ListOptions) 
 	glog.V(100).Infof(logMessage)
 
 	mcpList := new(mcv1.MachineConfigPoolList)
-	err = apiClient.List(context.TODO(), mcpList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), mcpList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list MCP objects due to %s", err.Error())
 
@@ -75,7 +75,6 @@ func ListMCPByMachineConfigSelector(
 	glog.V(100).Infof("GetByLabel returns MachineConfigPool with the specified label: %v", mcpLabel)
 
 	mcpList, err := ListMCP(apiClient, options...)
-
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +127,6 @@ func ListMCPWaitToBeStableFor(
 			_ = wait.PollUntilContextTimeout(
 				context.TODO(), fiveScds, stableDuration, true, func(ctx2 context.Context) (done bool, err error) {
 					mcpList, err := ListMCP(apiClient, options...)
-
 					if err != nil {
 						return false, err
 					}
@@ -169,7 +167,6 @@ func ListMCPWaitToBeStableFor(
 			// keep iterating in the outer wait.PollUntilContextTimeout waiting for cluster to be stable.
 			return false, nil
 		})
-
 	if err == nil {
 		glog.V(100).Infof("Cluster was stable during stableDuration: %v", stableDuration)
 	} else {

--- a/pkg/metallb/addresspool.go
+++ b/pkg/metallb/addresspool.go
@@ -90,10 +90,10 @@ func (builder *IPAddressPoolBuilder) Get() (*mlbtypes.IPAddressPool, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	ipAddressPool := &mlbtypes.IPAddressPool{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		ipAddressPool)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"IPAddressPool object %s does not exist in namespace %s",
@@ -116,6 +116,7 @@ func (builder *IPAddressPoolBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -132,7 +133,6 @@ func PullAddressPool(apiClient *clients.Settings, name, nsname string) (*IPAddre
 	}
 
 	err := apiClient.AttachScheme(mlbtypes.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add metallb scheme to client schemes")
 
@@ -214,7 +214,6 @@ func (builder *IPAddressPoolBuilder) Delete() (*IPAddressPoolBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete IPAddressPool: %w", err)
 	}
@@ -239,14 +238,12 @@ func (builder *IPAddressPoolBuilder) Update(force bool) (*IPAddressPoolBuilder, 
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("IPAddressPool", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("IPAddressPool", builder.Definition.Name, builder.Definition.Namespace))
@@ -310,7 +307,6 @@ func (builder *IPAddressPoolBuilder) WithOptions(options ...IPAddressPoolAdditio
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/metallb/bfdprofile.go
+++ b/pkg/metallb/bfdprofile.go
@@ -79,10 +79,10 @@ func (builder *BFDBuilder) Get() (*mlbtypes.BFDProfile, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	bfdProfile := &mlbtypes.BFDProfile{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		bfdProfile)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"BFDProfile object %s does not exist in namespace %s",
@@ -105,6 +105,7 @@ func (builder *BFDBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -121,7 +122,6 @@ func PullBFDProfile(apiClient *clients.Settings, name, nsname string) (*BFDBuild
 	}
 
 	err := apiClient.AttachScheme(mlbtypes.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add metallb scheme to client schemes")
 
@@ -204,7 +204,6 @@ func (builder *BFDBuilder) Delete() (*BFDBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete BFDProfile: %w", err)
 	}
@@ -229,14 +228,12 @@ func (builder *BFDBuilder) Update(force bool) (*BFDBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("BFDProfile", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("BFDProfile", builder.Definition.Name, builder.Definition.Namespace))
@@ -317,7 +314,6 @@ func (builder *BFDBuilder) WithOptions(options ...BFDAdditionalOptions) *BFDBuil
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/metallb/bgpadvertisement.go
+++ b/pkg/metallb/bgpadvertisement.go
@@ -79,6 +79,7 @@ func (builder *BGPAdvertisementBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -95,10 +96,10 @@ func (builder *BGPAdvertisementBuilder) Get() (*mlbtypes.BGPAdvertisement, error
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	bgpAdvertisement := &mlbtypes.BGPAdvertisement{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		bgpAdvertisement)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"BGPAdvertisement object %s does not exist in namespace %s",
@@ -170,7 +171,6 @@ func (builder *BGPAdvertisementBuilder) Create() (*BGPAdvertisementBuilder, erro
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create BGPAdvertisement")
 
@@ -203,7 +203,6 @@ func (builder *BGPAdvertisementBuilder) Delete() (*BGPAdvertisementBuilder, erro
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete BGPAdvertisement: %w", err)
 	}
@@ -234,15 +233,14 @@ func (builder *BGPAdvertisementBuilder) Update(force bool) (*BGPAdvertisementBui
 	}
 
 	builder.Object.Spec = builder.Definition.Spec
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("BGPAdvertisement", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("BGPAdvertisement", builder.Definition.Name, builder.Definition.Namespace))
@@ -436,7 +434,6 @@ func (builder *BGPAdvertisementBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/metallb/bgppeer.go
+++ b/pkg/metallb/bgppeer.go
@@ -147,10 +147,10 @@ func (builder *BGPPeerBuilder) Get() (*mlbtypesv1beta2.BGPPeer, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	bgpPeer := &mlbtypesv1beta2.BGPPeer{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		bgpPeer)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"Failed to Unmarshal BGPPeer: unstructured object to structure in namespace %s",
@@ -173,6 +173,7 @@ func (builder *BGPPeerBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -238,7 +239,6 @@ func (builder *BGPPeerBuilder) Create() (*BGPPeerBuilder, error) {
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -267,7 +267,6 @@ func (builder *BGPPeerBuilder) Delete() (*BGPPeerBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete BGPPeer: %w", err)
 	}
@@ -288,14 +287,12 @@ func (builder *BGPPeerBuilder) Update(force bool) (*BGPPeerBuilder, error) {
 	)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("BGPPeer", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("BGPPeer", builder.Definition.Name, builder.Definition.Namespace))
@@ -638,7 +635,6 @@ func (builder *BGPPeerBuilder) WithOptions(options ...BGPPeerAdditionalOptions) 
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/metallb/frr.go
+++ b/pkg/metallb/frr.go
@@ -88,7 +88,6 @@ func (builder *FrrConfigurationBuilder) Create() (*FrrConfigurationBuilder, erro
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create MetalLb")
 
@@ -112,9 +111,9 @@ func (builder *FrrConfigurationBuilder) Get() (*frrtypes.FRRConfiguration, error
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	frrConfig := &frrtypes.FRRConfiguration{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace}, frrConfig)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"metallb object %s does not exist in namespace %s",
@@ -147,7 +146,6 @@ func (builder *FrrConfigurationBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete frrConfiguration: %w", err)
 	}
@@ -175,6 +173,7 @@ func (builder *FrrConfigurationBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/metallb/frrnodestate.go
+++ b/pkg/metallb/frrnodestate.go
@@ -71,6 +71,7 @@ func (builder *FrrNodeStateBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if FrrNodeState %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -85,10 +86,10 @@ func (builder *FrrNodeStateBuilder) Get() (*frrtypes.FRRNodeState, error) {
 	glog.V(100).Infof("Collecting FrrNodeState object %s", builder.Definition.Name)
 
 	frrNodeState := &frrtypes.FRRNodeState{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeClient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, frrNodeState)
-
 	if err != nil {
 		glog.V(100).Infof("FrrNodeState object %s does not exist", builder.Definition.Name)
 

--- a/pkg/metallb/frrnodestate_test.go
+++ b/pkg/metallb/frrnodestate_test.go
@@ -16,6 +16,7 @@ var (
 
 func TestFrrNodeStateGet(t *testing.T) {
 	var runtimeObjects []runtime.Object
+
 	testCases := []struct {
 		testFrrNodeState    *FrrNodeStateBuilder
 		addToRuntimeObjects bool

--- a/pkg/metallb/frrnodestatelist.go
+++ b/pkg/metallb/frrnodestatelist.go
@@ -43,8 +43,8 @@ func ListFrrNodeState(
 	glog.V(100).Infof(logMessage)
 
 	frrNodeStateList := new(frrtypes.FRRNodeStateList)
-	err = apiClient.List(context.TODO(), frrNodeStateList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), frrNodeStateList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list FrrNodeStates due to %s", err.Error())
 

--- a/pkg/metallb/l2advertisement.go
+++ b/pkg/metallb/l2advertisement.go
@@ -133,6 +133,7 @@ func (builder *L2AdvertisementBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -149,10 +150,10 @@ func (builder *L2AdvertisementBuilder) Get() (*mlbtypes.L2Advertisement, error) 
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	l2Advertisement := &mlbtypes.L2Advertisement{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		l2Advertisement)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"L2Advertisement object %s does not exist in namespace %s",
@@ -177,7 +178,6 @@ func (builder *L2AdvertisementBuilder) Create() (*L2AdvertisementBuilder, error)
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -206,7 +206,6 @@ func (builder *L2AdvertisementBuilder) Delete() (*L2AdvertisementBuilder, error)
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete L2Advertisement: %w", err)
 	}
@@ -237,15 +236,14 @@ func (builder *L2AdvertisementBuilder) Update(force bool) (*L2AdvertisementBuild
 	}
 
 	builder.Object.Spec = builder.Definition.Spec
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("L2Advertisement", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("L2Advertisement", builder.Definition.Name, builder.Definition.Namespace))
@@ -358,7 +356,6 @@ func (builder *L2AdvertisementBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/metallb/metallb.go
+++ b/pkg/metallb/metallb.go
@@ -140,8 +140,8 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect MetalLb object due to %s", err.Error())
 	}
@@ -160,9 +160,9 @@ func (builder *Builder) Get() (*mlbtypes.MetalLB, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	metallb := &mlbtypes.MetalLB{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace}, metallb)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"metallb object %s does not exist in namespace %s",
@@ -186,7 +186,6 @@ func (builder *Builder) Create() (*Builder, error) {
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -215,7 +214,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete metallb: %w", err)
 	}
@@ -243,14 +241,12 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("metallb", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("metallb", builder.Definition.Name, builder.Definition.Namespace))
@@ -317,7 +313,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/monitoring/servicemonitor.go
+++ b/pkg/monitoring/servicemonitor.go
@@ -135,11 +135,11 @@ func (builder *Builder) Get() (*monv1.ServiceMonitor, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	serviceMonitorObj := &monv1.ServiceMonitor{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, serviceMonitorObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete serviceMonitor: %w", err)
 	}
@@ -207,6 +206,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -222,7 +222,6 @@ func (builder *Builder) Update() (*Builder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("serviceMonitor", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/nad/builder.go
+++ b/pkg/nad/builder.go
@@ -139,10 +139,10 @@ func (builder *Builder) Get() (*nadV1.NetworkAttachmentDefinition, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	network := &nadV1.NetworkAttachmentDefinition{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		network)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"NetworkAttachmentDefinition object %s does not exist in namespace %s",
@@ -170,14 +170,12 @@ func (builder *Builder) Create() (*Builder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.fillConfigureString()
-
 	if err != nil {
 		return builder, fmt.Errorf("failed create NAD object, could not marshal configuration %s", err.Error())
 	}
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create NAD object")
 
@@ -210,7 +208,6 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("fail to delete NAD object due to: %w", err)
 	}
@@ -235,8 +232,8 @@ func (builder *Builder) Update() (*Builder, error) {
 
 	builder.Definition.CreationTimestamp = metav1.Time{}
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -257,6 +254,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return nil == err || !k8serrors.IsNotFound(err)
@@ -333,7 +331,6 @@ func (builder *Builder) WithMasterPlugin(masterPlugin *MasterPlugin) *Builder {
 	}
 
 	masterPluginSting, err := json.Marshal(masterPlugin)
-
 	if err != nil {
 		builder.errorMsg = err.Error()
 
@@ -360,7 +357,6 @@ func (builder *Builder) WithPlugins(name string, plugins *[]Plugin) *Builder {
 	}
 
 	pluginsConfigString, err := json.Marshal(pluginsConfig)
-
 	if err != nil {
 		builder.errorMsg = err.Error()
 

--- a/pkg/nad/list.go
+++ b/pkg/nad/list.go
@@ -38,7 +38,6 @@ func List(apiClient *clients.Settings, nsname string) ([]*Builder, error) {
 	nadList := &nadV1.NetworkAttachmentDefinitionList{}
 
 	err = apiClient.List(context.TODO(), nadList, &goclient.ListOptions{Namespace: nsname})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list NADs in namespace: %s due to %s",
 			nsname, err.Error())

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -125,7 +125,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -170,6 +169,7 @@ func (builder *Builder) Update() (*Builder, error) {
 	glog.V(100).Infof("Updating the namespace %s with the namespace definition in the builder", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Namespaces().Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -193,7 +193,6 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Namespaces().Delete(context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -239,6 +238,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if namespace %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Namespaces().Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -297,7 +297,6 @@ func (builder *Builder) CleanObjects(cleanTimeout time.Duration, objects ...sche
 
 		err := builder.apiClient.Resource(resource).Namespace(builder.Definition.Name).DeleteCollection(
 			context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
-
 		if err != nil {
 			glog.V(100).Infof("Failed to remove resources: %s in namespace: %s",
 				resource.Resource, builder.Definition.Name)
@@ -322,7 +321,6 @@ func (builder *Builder) CleanObjects(cleanTimeout time.Duration, objects ...sche
 
 				return true, err
 			})
-
 		if err != nil {
 			glog.V(100).Infof("Failed to remove resources: %s in namespace: %s",
 				resource.Resource, builder.Definition.Name)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -73,8 +73,8 @@ func (builder *ConfigBuilder) Get() (*configv1.Network, error) {
 	glog.V(100).Infof("Getting network.config object %s", builder.Definition.Name)
 
 	network := &configv1.Network{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, network)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, network)
 	if err != nil {
 		glog.V(100).Infof("Failed to get network.config object %s: %v", builder.Definition.Name, err)
 
@@ -93,6 +93,7 @@ func (builder *ConfigBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if network.config %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/network/operator.go
+++ b/pkg/network/operator.go
@@ -72,6 +72,7 @@ func (builder *OperatorBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if network.operator %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -84,8 +85,8 @@ func (builder *OperatorBuilder) Get() (*operatorv1.Network, error) {
 	}
 
 	clusterNetwork := &operatorv1.Network{}
-	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, clusterNetwork)
 
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, clusterNetwork)
 	if err != nil {
 		glog.V(100).Infof("Failed to get network.operator object %s: %v", builder.Definition.Name, err)
 
@@ -129,22 +130,20 @@ func (builder *OperatorBuilder) SetLocalGWMode(state bool, timeout time.Duration
 
 	if builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.RoutingViaHost != state {
 		builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.RoutingViaHost = state
-		builder, err := builder.Update()
 
+		builder, err := builder.Update()
 		if err != nil {
 			return nil, err
 		}
 
 		err = builder.WaitUntilInCondition(
 			operatorv1.OperatorStatusTypeProgressing, 300*time.Second, operatorv1.ConditionTrue)
-
 		if err != nil {
 			return nil, err
 		}
 
 		err = builder.WaitUntilInCondition(
 			operatorv1.OperatorStatusTypeProgressing, timeout, operatorv1.ConditionFalse)
-
 		if err != nil {
 			return nil, err
 		}
@@ -168,22 +167,20 @@ func (builder *OperatorBuilder) SetMultiNetworkPolicy(state bool, timeout time.D
 
 	if *builder.Definition.Spec.UseMultiNetworkPolicy != state {
 		builder.Definition.Spec.UseMultiNetworkPolicy = &state
-		builder, err := builder.Update()
 
+		builder, err := builder.Update()
 		if err != nil {
 			return nil, err
 		}
 
 		err = builder.WaitUntilInCondition(
 			operatorv1.OperatorStatusTypeProgressing, 60*time.Second, operatorv1.ConditionTrue)
-
 		if err != nil {
 			return nil, err
 		}
 
 		err = builder.WaitUntilInCondition(
 			operatorv1.OperatorStatusTypeProgressing, timeout, operatorv1.ConditionFalse)
-
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/networkpolicy/list.go
+++ b/pkg/networkpolicy/list.go
@@ -34,7 +34,6 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	networkpolicyList, err := apiClient.NetworkPolicies(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list networkpolicies in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/networkpolicy/multinetegressrule.go
+++ b/pkg/networkpolicy/multinetegressrule.go
@@ -112,7 +112,6 @@ func (builder *EgressRuleBuilder) WithOptions(options ...EgressAdditionalOptions
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -166,7 +165,6 @@ func (builder *EgressRuleBuilder) WithCIDR(cidr string, except ...[]string) *Egr
 	}
 
 	_, _, err := net.ParseCIDR(cidr)
-
 	if err != nil {
 		glog.V(100).Infof("Invalid CIDR %s", cidr)
 
@@ -212,7 +210,6 @@ func (builder *EgressRuleBuilder) WithPeerPodSelectorAndCIDR(
 	}
 
 	_, _, err := net.ParseCIDR(cidr)
-
 	if err != nil {
 		glog.V(100).Infof("Invalid CIDR %s", cidr)
 

--- a/pkg/networkpolicy/multinetingressrule.go
+++ b/pkg/networkpolicy/multinetingressrule.go
@@ -111,7 +111,6 @@ func (builder *IngressRuleBuilder) WithOptions(options ...IngressAdditionalOptio
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -160,7 +159,6 @@ func (builder *IngressRuleBuilder) WithCIDR(cidr string, except ...[]string) *In
 	glog.V(100).Infof("Adding peer CIDR %s to Ingress Rule", cidr)
 
 	_, _, err := net.ParseCIDR(cidr)
-
 	if err != nil {
 		glog.V(100).Infof("Invalid CIDR %s", cidr)
 

--- a/pkg/networkpolicy/multinetworkpolicy.go
+++ b/pkg/networkpolicy/multinetworkpolicy.go
@@ -250,10 +250,10 @@ func (builder *MultiNetworkPolicyBuilder) Get() (*v1beta1.MultiNetworkPolicy, er
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	network := &v1beta1.MultiNetworkPolicy{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		network)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"MultiNetworkPolicy object %s does not exist in namespace %s",
@@ -277,7 +277,6 @@ func (builder *MultiNetworkPolicyBuilder) Create() (*MultiNetworkPolicyBuilder, 
 	var err error
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create MultiNetworkPolicy object")
 
@@ -300,6 +299,7 @@ func (builder *MultiNetworkPolicyBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -321,7 +321,6 @@ func (builder *MultiNetworkPolicyBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete MultiNetworkPolicy: %w", err)
 	}
@@ -345,7 +344,6 @@ func (builder *MultiNetworkPolicyBuilder) Update() (*MultiNetworkPolicyBuilder, 
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}

--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -239,10 +239,10 @@ func (builder *NetworkPolicyBuilder) Get() (*netv1.NetworkPolicy, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	netPolicy := &netv1.NetworkPolicy{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		netPolicy)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"NetworkPolicy object %s does not exist in namespace %s",
@@ -266,7 +266,6 @@ func (builder *NetworkPolicyBuilder) Create() (*NetworkPolicyBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create NetworkPolicy object")
 
@@ -289,6 +288,7 @@ func (builder *NetworkPolicyBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -336,7 +336,6 @@ func (builder *NetworkPolicyBuilder) Update() (*NetworkPolicyBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}

--- a/pkg/nfd/nodefeaturediscovery.go
+++ b/pkg/nfd/nodefeaturediscovery.go
@@ -135,11 +135,11 @@ func (builder *Builder) Get() (*nfdv1.NodeFeatureDiscovery, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nodeFeatureDiscovery := &nfdv1.NodeFeatureDiscovery{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nodeFeatureDiscovery)
-
 	if err != nil {
 		glog.V(100).Infof("NodeFeatureDiscovery object %s does not exist in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)
@@ -161,8 +161,8 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect NodeFeatureDiscovery object due to %s", err.Error())
 	}
@@ -189,7 +189,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("cannot delete NodeFeaturediscovery: %w", err)
 	}
@@ -211,7 +210,6 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -230,14 +228,12 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("NodeFeatureDiscovery", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("NodeFeatureDiscovery", builder.Definition.Name, builder.Definition.Namespace))
@@ -261,7 +257,6 @@ func getNodeFeatureDiscoveryFromAlmExample(almExample string) (*nfdv1.NodeFeatur
 	}
 
 	err := json.Unmarshal([]byte(almExample), &nodeFeatureDiscoveryList.Items)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nfd/nodefeaturerule.go
+++ b/pkg/nfd/nodefeaturerule.go
@@ -134,7 +134,6 @@ func getNodeFeatureRuleFromAlmExample(almExample string) (*nfdv1.NodeFeatureRule
 	}
 
 	err := json.Unmarshal([]byte(almExample), &nodeFeatureRuleList.Items)
-
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +163,6 @@ func (builder *NodeFeatureRuleBuilder) Create() (*NodeFeatureRuleBuilder, error)
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -184,8 +182,8 @@ func (builder *NodeFeatureRuleBuilder) Exists() bool {
 		builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect NodeFeatureRule object due to %s", err.Error())
 	}
@@ -203,11 +201,11 @@ func (builder *NodeFeatureRuleBuilder) Get() (*nfdv1.NodeFeatureRule, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	NodeFeatureRule := &nfdv1.NodeFeatureRule{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, NodeFeatureRule)
-
 	if err != nil {
 		glog.V(100).Infof("NodeFeatureRule object %s does not exist in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)

--- a/pkg/nmstate/nmstate.go
+++ b/pkg/nmstate/nmstate.go
@@ -73,8 +73,8 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if NMState %s exists", builder.Definition.Name)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect NMState object due to %s", err.Error())
 	}
@@ -91,8 +91,8 @@ func (builder *Builder) Get() (*nmstateV1.NMState, error) {
 	glog.V(100).Infof("Collecting NMState object %s", builder.Definition.Name)
 
 	nmstate := &nmstateV1.NMState{}
-	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, nmstate)
 
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, nmstate)
 	if err != nil {
 		glog.V(100).Infof("NMState object %s does not exist", builder.Definition.Name)
 
@@ -142,7 +142,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete NMState: %w", err)
 	}
@@ -161,7 +160,6 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	glog.V(100).Infof("Updating the NMState object", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	} else if force {
@@ -169,7 +167,6 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 			msg.FailToUpdateNotification("NMState", builder.Definition.Name))
 
 		builder, err := builder.Delete()
-
 		if err != nil {
 			glog.V(100).Infof(
 				msg.FailToUpdateError("NMState", builder.Definition.Name))

--- a/pkg/nmstate/nodenetworkstate.go
+++ b/pkg/nmstate/nodenetworkstate.go
@@ -43,8 +43,8 @@ func (builder *StateBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if NodeNetworkState %s exists", builder.Object.Name)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect NodeNetworkState object due to %s", err.Error())
 	}
@@ -61,10 +61,10 @@ func (builder *StateBuilder) Get() (*nmstateV1beta1.NodeNetworkState, error) {
 	glog.V(100).Infof("Collecting NodeNetworkState object %s", builder.Object.Name)
 
 	nodeNetworkState := &nmstateV1beta1.NodeNetworkState{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Object.Name,
 	}, nodeNetworkState)
-
 	if err != nil {
 		glog.V(100).Infof("NodeNetworkState object %s does not exist", builder.Object.Name)
 

--- a/pkg/nmstate/nodenetworkstate_test.go
+++ b/pkg/nmstate/nodenetworkstate_test.go
@@ -309,8 +309,8 @@ func newNodeNetworkStateBuilder(apiClient *clients.Settings, name string) *State
 		},
 	}
 	byteDesiredState, _ := yaml.Marshal(desiredState)
-	err := apiClient.AttachScheme(nmstateV1beta1.AddToScheme)
 
+	err := apiClient.AttachScheme(nmstateV1beta1.AddToScheme)
 	if err != nil {
 		return nil
 	}

--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -107,11 +107,11 @@ func (builder *PolicyBuilder) Get() (*nmstateV1.NodeNetworkConfigurationPolicy, 
 		"Collecting NodeNetworkConfigurationPolicy object %s", builder.Definition.Name)
 
 	nmstatePolicy := &nmstateV1.NodeNetworkConfigurationPolicy{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nmstatePolicy)
-
 	if err != nil {
 		glog.V(100).Infof("NodeNetworkConfigurationPolicy object %s does not exist", builder.Definition.Name)
 
@@ -132,6 +132,7 @@ func (builder *PolicyBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -177,7 +178,6 @@ func (builder *PolicyBuilder) Delete() (*PolicyBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete NodeNetworkConfigurationPolicy: %w", err)
 	}
@@ -199,7 +199,6 @@ func (builder *PolicyBuilder) Update(force bool) (*PolicyBuilder, error) {
 	)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	} else if force {
@@ -208,7 +207,6 @@ func (builder *PolicyBuilder) Update(force bool) (*PolicyBuilder, error) {
 				msg.FailToUpdateNotification("NodeNetworkConfigurationPolicy", builder.Definition.Name))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("NodeNetworkConfigurationPolicy", builder.Definition.Name))
@@ -536,7 +534,6 @@ func (builder *PolicyBuilder) WithOptions(options ...AdditionalOptions) *PolicyB
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -570,7 +567,6 @@ func (builder *PolicyBuilder) WaitUntilCondition(condition nmstateShared.Conditi
 	return wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, nil
 			}
@@ -631,7 +627,6 @@ func (builder *PolicyBuilder) withInterface(networkInterface NetworkInterface) *
 	var CurrentState DesiredState
 
 	err := yaml.Unmarshal(builder.Definition.Spec.DesiredState.Raw, &CurrentState)
-
 	if err != nil {
 		glog.V(100).Infof("Failed Unmarshal DesiredState")
 
@@ -643,7 +638,6 @@ func (builder *PolicyBuilder) withInterface(networkInterface NetworkInterface) *
 	CurrentState.Interfaces = append(CurrentState.Interfaces, networkInterface)
 
 	desiredStateYaml, err := yaml.Marshal(CurrentState)
-
 	if err != nil {
 		glog.V(100).Infof("Failed Marshal DesiredState")
 

--- a/pkg/nmstate/policylist.go
+++ b/pkg/nmstate/policylist.go
@@ -42,8 +42,8 @@ func ListPolicy(apiClient *clients.Settings, options ...goclient.ListOptions) ([
 	glog.V(100).Infof(logMessage)
 
 	policyList := &nmstateV1.NodeNetworkConfigurationPolicyList{}
-	err = apiClient.List(context.TODO(), policyList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), policyList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list NodeNetworkConfigurationPolicy due to %s", err.Error())
 

--- a/pkg/nodes/list.go
+++ b/pkg/nodes/list.go
@@ -82,6 +82,7 @@ func ListExternalIPv4Networks(apiClient *clients.Settings, options ...metav1.Lis
 			return nil, fmt.Errorf(
 				"error getting external IPv4 address from node %s due to %w", node.Definition.Name, err)
 		}
+
 		ipV4ExternalAddresses = append(ipV4ExternalAddresses, extNodeNetwork)
 	}
 
@@ -107,6 +108,7 @@ func ListExternalIPv6Networks(apiClient *clients.Settings, options ...metav1.Lis
 			return nil, fmt.Errorf(
 				"error getting external IPv6 address from node %s due to %w", node.Definition.Name, err)
 		}
+
 		ipV6ExternalAddresses = append(ipV6ExternalAddresses, extNodeNetwork)
 	}
 
@@ -146,7 +148,6 @@ func WaitForAllNodesAreReady(apiClient *clients.Settings,
 
 			return true, nil
 		})
-
 	if err == nil {
 		glog.V(100).Infof("All nodes were found in the Ready State during availableDuration: %v",
 			timeout)
@@ -177,6 +178,7 @@ func WaitForAllNodesToReboot(apiClient *clients.Settings,
 	globalStartTime := time.Now().Unix()
 	readyNodes := []string{}
 	rebootedNodes := []string{}
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), backoff, globalRebootTimeout, true, func(ctx context.Context) (done bool, err error) {
 			for _, node := range nodesList {
@@ -205,7 +207,6 @@ func WaitForAllNodesToReboot(apiClient *clients.Settings,
 
 			return len(readyNodes) == len(nodesList), nil
 		})
-
 	if err == nil {
 		globalRebootDuration := time.Now().Unix() - globalStartTime
 		glog.V(100).Infof("All nodes were successfully rebooted during: %v", globalRebootDuration)

--- a/pkg/nodes/node.go
+++ b/pkg/nodes/node.go
@@ -163,6 +163,7 @@ func (builder *Builder) Update() (*Builder, error) {
 	builder.Definition.ResourceVersion = ""
 
 	var err error
+
 	builder.Object, err = builder.apiClient.CoreV1().Nodes().Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -178,6 +179,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if node %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.CoreV1().Nodes().Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -204,7 +206,6 @@ func (builder *Builder) Delete() error {
 		context.TODO(),
 		builder.Definition.Name,
 		metav1.DeleteOptions{})
-
 	if err != nil {
 		return fmt.Errorf("can not delete node %s due to %w", builder.Definition.Name, err)
 	}
@@ -256,7 +257,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -307,8 +307,8 @@ func (builder *Builder) ExternalIPv4Network() (string, error) {
 	}
 
 	var extNetwork ExternalNetworks
-	err := json.Unmarshal([]byte(builder.Object.Annotations[ovnExternalAddresses]), &extNetwork)
 
+	err := json.Unmarshal([]byte(builder.Object.Annotations[ovnExternalAddresses]), &extNetwork)
 	if err != nil {
 		return "",
 			fmt.Errorf("error to unmarshal node %s, annotation %s due to %w", builder.Object.Name, ovnExternalAddresses, err)
@@ -334,8 +334,8 @@ func (builder *Builder) ExternalIPv6Network() (string, error) {
 	}
 
 	var extNetwork ExternalNetworks
-	err := json.Unmarshal([]byte(builder.Object.Annotations[ovnExternalAddresses]), &extNetwork)
 
+	err := json.Unmarshal([]byte(builder.Object.Annotations[ovnExternalAddresses]), &extNetwork)
 	if err != nil {
 		return "",
 			fmt.Errorf("error to unmarshal node %s, annotation %s due to %w", builder.Object.Name, ovnExternalAddresses, err)

--- a/pkg/nodesconfig/nodesconfig.go
+++ b/pkg/nodesconfig/nodesconfig.go
@@ -70,10 +70,10 @@ func (builder *Builder) Get() (*configV1.Node, error) {
 	glog.V(100).Infof("Getting existing nodesConfig with name %s from cluster", builder.Definition.Name)
 
 	nodesConfig := &configV1.Node{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, nodesConfig)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get nodesConfig object %s from cluster due to: %w",
 			builder.Definition.Name, err)
@@ -93,6 +93,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if nodesConfig %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/nrop/nrop.go
+++ b/pkg/nrop/nrop.go
@@ -114,10 +114,10 @@ func (builder *Builder) Get() (*nropv1.NUMAResourcesOperator, error) {
 	glog.V(100).Infof("Getting NUMAResourcesOperator %s", builder.Definition.Name)
 
 	nropObj := &nropv1.NUMAResourcesOperator{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, nropObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete NUMAResourcesOperator: %w", err)
 	}
@@ -181,6 +180,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if NUMAResourcesOperator %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -195,7 +195,6 @@ func (builder *Builder) Update() (*Builder, error) {
 	glog.V(100).Infof("Updating NUMAResourcesOperator %s", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("NUMAResourcesOperator", builder.Definition.Name))

--- a/pkg/nrop/nropscheduler.go
+++ b/pkg/nrop/nropscheduler.go
@@ -135,11 +135,11 @@ func (builder *SchedulerBuilder) Get() (*nropv1.NUMAResourcesScheduler, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nrosObj := &nropv1.NUMAResourcesScheduler{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nrosObj)
-
 	if err != nil {
 		glog.V(100).Infof("NUMAResourcesScheduler object %s not found in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -190,7 +190,6 @@ func (builder *SchedulerBuilder) Delete() (*SchedulerBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete NUMAResourcesScheduler %s from namespace %s due to %w",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -211,6 +210,7 @@ func (builder *SchedulerBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -226,7 +226,6 @@ func (builder *SchedulerBuilder) Update() (*SchedulerBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("NUMAResourcesScheduler", builder.Definition.Name))

--- a/pkg/nto/performanceprofile.go
+++ b/pkg/nto/performanceprofile.go
@@ -1,5 +1,4 @@
 package nto //nolint:misspell
-
 import (
 	"context"
 	"fmt"
@@ -407,13 +406,11 @@ func (builder *Builder) Create() (*Builder, error) {
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			return nil, err
 		}
 
 		builder.Object, err = builder.Get()
-
 		if err != nil {
 			return nil, err
 		}
@@ -431,6 +428,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if PerformanceProfile %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -449,7 +447,6 @@ func (builder *Builder) Get() (*performanceprofilev2.PerformanceProfile, error) 
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, module)
-
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +472,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, err
 	}
@@ -494,7 +490,6 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	glog.V(100).Infof("Updating the PerformanceProfile object: %s", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -502,7 +497,6 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 					"Note: Force flag set, executed delete/create methods instead", builder.Definition.Name)
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					"Failed to update the PerformanceProfile object %s, "+

--- a/pkg/nto/performanceprofilelist.go
+++ b/pkg/nto/performanceprofilelist.go
@@ -42,8 +42,8 @@ func ListProfiles(apiClient *clients.Settings, options ...goclient.ListOptions) 
 	glog.V(100).Infof(logMessage)
 
 	var performanceProfiles performanceprofilev2.PerformanceProfileList
-	err = apiClient.List(context.TODO(), &performanceProfiles, &passedOptions)
 
+	err = apiClient.List(context.TODO(), &performanceProfiles, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list PerformanceProfiles due to %s", err.Error())
 
@@ -71,7 +71,6 @@ func CleanAllPerformanceProfiles(apiClient *clients.Settings, options ...goclien
 	glog.V(100).Infof("Cleaning up PerformanceProfiles")
 
 	policies, err := ListProfiles(apiClient, options...)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list PerformanceProfiles")
 
@@ -80,7 +79,6 @@ func CleanAllPerformanceProfiles(apiClient *clients.Settings, options ...goclien
 
 	for _, policy := range policies {
 		_, err = policy.Delete()
-
 		if err != nil {
 			glog.V(100).Infof("Failed to delete PerformanceProfiles: %s", policy.Object.Name)
 

--- a/pkg/nto/tuned.go
+++ b/pkg/nto/tuned.go
@@ -132,11 +132,11 @@ func (builder *TunedBuilder) Get() (*tunedv1.Tuned, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	tunedObj := &tunedv1.Tuned{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, tunedObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,6 @@ func (builder *TunedBuilder) Delete() (*TunedBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete tuned: %w", err)
 	}
@@ -203,6 +202,7 @@ func (builder *TunedBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -218,7 +218,6 @@ func (builder *TunedBuilder) Update() (*TunedBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("tuned", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/nvidiagpu/clusterpolicy.go
+++ b/pkg/nvidiagpu/clusterpolicy.go
@@ -47,7 +47,6 @@ func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) 
 	}
 
 	clusterPolicy, err := getClusterPolicyFromAlmExample(almExample)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"error initializing ClusterPolicy from alm-examples: %s", err.Error())
@@ -129,8 +128,8 @@ func (builder *Builder) Get() (*nvidiagpuv1.ClusterPolicy, error) {
 		"Collecting ClusterPolicy object %s", builder.Definition.Name)
 
 	clusterPolicy := &nvidiagpuv1.ClusterPolicy{}
-	err := builder.apiClient.Get(context.TODO(), runtimeClient.ObjectKey{Name: builder.Definition.Name}, clusterPolicy)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeClient.ObjectKey{Name: builder.Definition.Name}, clusterPolicy)
 	if err != nil {
 		glog.V(100).Infof(
 			"ClusterPolicy object %s does not exist", builder.Definition.Name)
@@ -151,8 +150,8 @@ func (builder *Builder) Exists() bool {
 		"Checking if ClusterPolicy %s exists", builder.Definition.Name)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect ClusterPolicy object due to %s", err.Error())
 	}
@@ -175,7 +174,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("cannot delete clusterpolicy: %w", err)
 	}
@@ -216,13 +214,11 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	glog.V(100).Infof("Updating the ClusterPolicy object named:  %s", builder.Definition.Name)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(msg.FailToUpdateNotification("clusterpolicy", builder.Definition.Name))
 
 			builder, err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("clusterpolicy", builder.Definition.Name))
@@ -278,7 +274,6 @@ func getClusterPolicyFromAlmExample(almExample string) (*nvidiagpuv1.ClusterPoli
 	}
 
 	err := json.Unmarshal([]byte(almExample), &clusterPolicyList.Items)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oadp/dataprotectionapplication.go
+++ b/pkg/oadp/dataprotectionapplication.go
@@ -165,7 +165,6 @@ func (builder *DPABuilder) Get() (*oadpv1alpha1.DataProtectionApplication, error
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, dataprotectionapplication)
-
 	if err != nil {
 		return nil, err
 	}
@@ -183,6 +182,7 @@ func (builder *DPABuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -224,7 +224,6 @@ func (builder *DPABuilder) Update(force bool) (*DPABuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -268,7 +267,6 @@ func (builder *DPABuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete dataprotectionapplication: %w", err)
 	}

--- a/pkg/oadp/dataprotectionapplicationlist.go
+++ b/pkg/oadp/dataprotectionapplicationlist.go
@@ -49,8 +49,8 @@ func ListDataProtectionApplication(
 	glog.V(100).Infof(logMessage)
 
 	dataprotectionapplications := new(oadpv1alpha1.DataProtectionApplicationList)
-	err := apiClient.List(context.TODO(), dataprotectionapplications, &passedOptions)
 
+	err := apiClient.List(context.TODO(), dataprotectionapplications, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all dataprotectionapplications due to %s", err.Error())
 

--- a/pkg/oauth/oauthclient.go
+++ b/pkg/oauth/oauthclient.go
@@ -73,10 +73,10 @@ func (builder *OAuthClientBuilder) Get() (*oauthv1.OAuthClient, error) {
 	glog.V(100).Infof("Fetching existing OAuthClient with name %s from cluster", builder.Definition.Name)
 
 	oauthClient := &oauthv1.OAuthClient{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, oauthClient)
-
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,6 @@ func (builder *OAuthClientBuilder) Create() (*OAuthClientBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err == nil {
 			builder.Object = builder.Definition
 		}
@@ -113,6 +112,7 @@ func (builder *OAuthClientBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if OAuthClient %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -131,7 +131,6 @@ func (builder *OAuthClientBuilder) Update() (*OAuthClientBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -157,7 +156,6 @@ func (builder *OAuthClientBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("error: cannot delete OAuthClient: %w", err)
 	}

--- a/pkg/ocm/kac.go
+++ b/pkg/ocm/kac.go
@@ -135,11 +135,11 @@ func (builder *KACBuilder) Get() (*kacv1.KlusterletAddonConfig, error) {
 		"Getting KlusterletAddonConfig object %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	klusterletAddonConfig := &kacv1.KlusterletAddonConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, klusterletAddonConfig)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"KlusterletAddonConfig object %s does not exist in namespace %s",
@@ -161,6 +161,7 @@ func (builder *KACBuilder) Exists() bool {
 		"Checking if KlusterletAddonConfig %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -279,15 +280,16 @@ func (builder *KACBuilder) WaitUntilSearchCollectorEnabled(timeout time.Duration
 	}
 
 	var err error
-	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, timeout, true, func(context.Context) (bool, error) {
-		builder.Object, err = builder.Get()
-		if err != nil {
-			return false, nil
-		}
 
-		return builder.Object.Spec.SearchCollectorConfig.Enabled, nil
-	})
+	err = wait.PollUntilContextTimeout(
+		context.TODO(), time.Second, timeout, true, func(context.Context) (bool, error) {
+			builder.Object, err = builder.Get()
+			if err != nil {
+				return false, nil
+			}
 
+			return builder.Object.Spec.SearchCollectorConfig.Enabled, nil
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/kac_test.go
+++ b/pkg/ocm/kac_test.go
@@ -276,6 +276,7 @@ func TestKACUpdate(t *testing.T) {
 		// the update will not fail.
 		if testCase.alreadyExists {
 			var err error
+
 			kacBuilder, err = kacBuilder.Create()
 
 			assert.Nil(t, err)

--- a/pkg/ocm/klusterlet.go
+++ b/pkg/ocm/klusterlet.go
@@ -117,8 +117,8 @@ func (builder *KlusterletBuilder) Get() (*operatorv1.Klusterlet, error) {
 	glog.V(100).Infof("Getting Klusterlet object %s", builder.Definition.Name)
 
 	klusterlet := &operatorv1.Klusterlet{}
-	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, klusterlet)
 
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, klusterlet)
 	if err != nil {
 		glog.V(100).Infof("Failed to get Klusterlet object %s: %v", builder.Definition.Name, err)
 
@@ -137,6 +137,7 @@ func (builder *KlusterletBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if Klusterlet %s", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/ocm/managedcluster.go
+++ b/pkg/ocm/managedcluster.go
@@ -89,7 +89,6 @@ func (builder *ManagedClusterBuilder) WithOptions(options ...ManagedClusterAddit
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -226,10 +225,10 @@ func (builder *ManagedClusterBuilder) Get() (*clusterv1.ManagedCluster, error) {
 	glog.V(100).Infof("Getting ManagedCluster object %s", builder.Definition.Name)
 
 	managedCluster := &clusterv1.ManagedCluster{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, managedCluster)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get ManagedCluster object %s: %v", builder.Definition.Name, err)
 
@@ -248,6 +247,7 @@ func (builder *ManagedClusterBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if ManagedCluster %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -294,8 +294,8 @@ func (builder *ManagedClusterBuilder) WaitForLabel(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Info("Failed to get ManagedCluster %s: %v", builder.Definition.Name, err)
 
@@ -312,7 +312,6 @@ func (builder *ManagedClusterBuilder) WaitForLabel(
 
 			return exists, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/placementbinding.go
+++ b/pkg/ocm/placementbinding.go
@@ -146,6 +146,7 @@ func (builder *PlacementBindingBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -166,7 +167,6 @@ func (builder *PlacementBindingBuilder) Get() (*policiesv1.PlacementBinding, err
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, placementBinding)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get placementBinding %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -219,7 +219,6 @@ func (builder *PlacementBindingBuilder) Delete() (*PlacementBindingBuilder, erro
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete placementBinding: %w", err)
 	}
@@ -246,8 +245,8 @@ func (builder *PlacementBindingBuilder) Update(force bool) (*PlacementBindingBui
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(

--- a/pkg/ocm/placementbindingList.go
+++ b/pkg/ocm/placementbindingList.go
@@ -44,8 +44,8 @@ func ListPlacementBindingsInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	placementBindingList := new(policiesv1.PlacementBindingList)
-	err = apiClient.List(context.TODO(), placementBindingList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), placementBindingList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all placementBindings in all namespaces due to %s", err.Error())
 

--- a/pkg/ocm/placementrule.go
+++ b/pkg/ocm/placementrule.go
@@ -132,6 +132,7 @@ func (builder *PlacementRuleBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -152,7 +153,6 @@ func (builder *PlacementRuleBuilder) Get() (*placementrulev1.PlacementRule, erro
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, placementRule)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get placementrule %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -231,8 +231,8 @@ func (builder *PlacementRuleBuilder) Update(force bool) (*PlacementRuleBuilder, 
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(

--- a/pkg/ocm/placementrulelist.go
+++ b/pkg/ocm/placementrulelist.go
@@ -44,8 +44,8 @@ func ListPlacementrulesInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	placementRuleList := new(placementrulev1.PlacementRuleList)
-	err = apiClient.List(context.TODO(), placementRuleList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), placementRuleList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all placementrules in all namespaces due to %s", err.Error())
 

--- a/pkg/ocm/policy.go
+++ b/pkg/ocm/policy.go
@@ -147,6 +147,7 @@ func (builder *PolicyBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -167,7 +168,6 @@ func (builder *PolicyBuilder) Get() (*policiesv1.Policy, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, policy)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get policy %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -220,7 +220,6 @@ func (builder *PolicyBuilder) Delete() (*PolicyBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete policy: %w", err)
 	}
@@ -246,8 +245,8 @@ func (builder *PolicyBuilder) Update(force bool) (*PolicyBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -395,6 +394,7 @@ func (builder *PolicyBuilder) WaitForStatusMessageToContain(
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.Get()
@@ -413,7 +413,6 @@ func (builder *PolicyBuilder) WaitForStatusMessageToContain(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/policylist.go
+++ b/pkg/ocm/policylist.go
@@ -46,8 +46,8 @@ func ListPoliciesInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	policyList := new(policiesv1.PolicyList)
-	err = apiClient.List(context.TODO(), policyList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), policyList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all policies in all namespaces due to %s", err.Error())
 

--- a/pkg/ocm/policyset.go
+++ b/pkg/ocm/policyset.go
@@ -144,6 +144,7 @@ func (builder *PolicySetBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -164,7 +165,6 @@ func (builder *PolicySetBuilder) Get() (*policiesv1beta1.PolicySet, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, policySet)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get policySet %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -217,7 +217,6 @@ func (builder *PolicySetBuilder) Delete() (*PolicySetBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete policySet: %w", err)
 	}
@@ -244,8 +243,8 @@ func (builder *PolicySetBuilder) Update(force bool) (*PolicySetBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(

--- a/pkg/ocm/policysetlist.go
+++ b/pkg/ocm/policysetlist.go
@@ -44,8 +44,8 @@ func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	policySetList := new(policiesv1beta1.PolicySetList)
-	err = apiClient.List(context.TODO(), policySetList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), policySetList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all policySets in all namespaces due to %s", err.Error())
 

--- a/pkg/olm/catalogsource.go
+++ b/pkg/olm/catalogsource.go
@@ -157,10 +157,10 @@ func (builder *CatalogSourceBuilder) Get() (*oplmV1alpha1.CatalogSource, error) 
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	catalogSource := &oplmV1alpha1.CatalogSource{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		catalogSource)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"CatalogSource object %s does not exist in namespace %s",
@@ -187,14 +187,12 @@ func (builder *CatalogSourceBuilder) Update(force bool) (*CatalogSourceBuilder, 
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("CatalogSource", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("CatalogSource", builder.Definition.Name, builder.Definition.Namespace))
@@ -220,6 +218,7 @@ func (builder *CatalogSourceBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -243,7 +242,6 @@ func (builder *CatalogSourceBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/olm/catalogsourcelist.go
+++ b/pkg/olm/catalogsourcelist.go
@@ -23,7 +23,6 @@ func ListCatalogSources(
 	}
 
 	err := apiClient.AttachScheme(oplmV1alpha1.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add oplmV1alpha1 scheme to client schemes")
 
@@ -55,8 +54,8 @@ func ListCatalogSources(
 	passedOptions.Namespace = nsname
 
 	catalogSourceList := new(oplmV1alpha1.CatalogSourceList)
-	err = apiClient.List(context.TODO(), catalogSourceList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), catalogSourceList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list catalogsources in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/olm/clusterserviceversion.go
+++ b/pkg/olm/clusterserviceversion.go
@@ -87,10 +87,10 @@ func (builder *ClusterServiceVersionBuilder) Get() (*oplmV1alpha1.ClusterService
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterServiceVersion := &oplmV1alpha1.ClusterServiceVersion{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		clusterServiceVersion)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"ClusterServiceVersion object %s does not exist in namespace %s",
@@ -113,6 +113,7 @@ func (builder *ClusterServiceVersionBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -137,7 +138,6 @@ func (builder *ClusterServiceVersionBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,6 @@ func (builder *ClusterServiceVersionBuilder) IsSuccessful() (bool, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	phase, err := builder.GetPhase()
-
 	if err != nil {
 		return false, fmt.Errorf("failed to get phase value for %s clusterserviceversion in %s namespace due to %w",
 			builder.Definition.Name, builder.Definition.Namespace, err)

--- a/pkg/olm/clusterserviceversionlist.go
+++ b/pkg/olm/clusterserviceversionlist.go
@@ -24,7 +24,6 @@ func ListClusterServiceVersion(
 	}
 
 	err := apiClient.AttachScheme(oplmV1alpha1.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add oplmV1alpha1 scheme to client schemes")
 
@@ -54,8 +53,8 @@ func ListClusterServiceVersion(
 	glog.V(100).Infof(logMessage)
 
 	csvList := new(oplmV1alpha1.ClusterServiceVersionList)
-	err = apiClient.List(context.TODO(), csvList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), csvList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list clusterserviceversion in the nsname %s due to %s", nsname, err.Error())
 
@@ -103,7 +102,6 @@ func ListClusterServiceVersionWithNamePattern(
 		namePattern, nsname)
 
 	notFilteredCsvList, err := ListClusterServiceVersion(apiClient, nsname, options...)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list all clusterserviceversions in namespace %s due to %s",
 			nsname, err.Error())
@@ -133,7 +131,6 @@ func ListClusterServiceVersionInAllNamespaces(
 	}
 
 	err := apiClient.AttachScheme(oplmV1alpha1.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add oplmV1alpha1 scheme to client schemes")
 
@@ -157,8 +154,8 @@ func ListClusterServiceVersionInAllNamespaces(
 	glog.V(100).Infof(logMessage)
 
 	csvList := new(oplmV1alpha1.ClusterServiceVersionList)
-	err = apiClient.List(context.TODO(), csvList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), csvList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list CSVs in all namespaces due to %s", err.Error())
 

--- a/pkg/olm/installplan.go
+++ b/pkg/olm/installplan.go
@@ -134,10 +134,10 @@ func (builder *InstallPlanBuilder) Get() (*operatorsV1alpha1.InstallPlan, error)
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	installPlan := &operatorsV1alpha1.InstallPlan{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		installPlan)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"InstallPlan object %s does not exist in namespace %s",
@@ -182,6 +182,7 @@ func (builder *InstallPlanBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -206,7 +207,6 @@ func (builder *InstallPlanBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,6 @@ func (builder *InstallPlanBuilder) Update() (*InstallPlanBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}

--- a/pkg/olm/installplanlist.go
+++ b/pkg/olm/installplanlist.go
@@ -27,7 +27,6 @@ func ListInstallPlan(
 	}
 
 	err := apiClient.AttachScheme(oplmV1alpha1.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add oplmV1alpha1 scheme to client schemes")
 
@@ -51,8 +50,8 @@ func ListInstallPlan(
 	glog.V(100).Infof(logMessage)
 
 	installPlanList := new(oplmV1alpha1.InstallPlanList)
-	err = apiClient.List(context.TODO(), installPlanList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), installPlanList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list all installplan in namespace %s due to %s",
 			nsname, err.Error())

--- a/pkg/olm/operatorgroup.go
+++ b/pkg/olm/operatorgroup.go
@@ -90,10 +90,10 @@ func (builder *OperatorGroupBuilder) Get() (*operatorsv1.OperatorGroup, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	operatorGroup := &operatorsv1.OperatorGroup{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		operatorGroup)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"OperatorGroup object %s does not exist in namespace %s",
@@ -137,6 +137,7 @@ func (builder *OperatorGroupBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -161,7 +162,6 @@ func (builder *OperatorGroupBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,6 @@ func (builder *OperatorGroupBuilder) Update() (*OperatorGroupBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}

--- a/pkg/olm/packagemanifest.go
+++ b/pkg/olm/packagemanifest.go
@@ -41,7 +41,6 @@ func PullPackageManifest(apiClient *clients.Settings, name, nsname string) (*Pac
 	}
 
 	err := apiClient.AttachScheme(operatorv1.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add operatorv1 scheme to client schemes")
 
@@ -92,7 +91,6 @@ func PullPackageManifestByCatalog(apiClient *clients.Settings, name, nsname,
 	}
 
 	fieldSelector, err := fields.ParseSelector(fmt.Sprintf("metadata.name=%s", name))
-
 	if err != nil {
 		glog.V(100).Infof("Failed to parse invalid packageManifest name %s", name)
 
@@ -106,7 +104,6 @@ func PullPackageManifestByCatalog(apiClient *clients.Settings, name, nsname,
 	}
 
 	labelSelector, err := labels.Parse(fmt.Sprintf("catalog=%s", catalog))
-
 	if err != nil {
 		glog.V(100).Infof("Failed to parse invalid catalog name %s", catalog)
 
@@ -117,7 +114,6 @@ func PullPackageManifestByCatalog(apiClient *clients.Settings, name, nsname,
 		LabelSelector: labelSelector,
 		FieldSelector: fieldSelector,
 	})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list PackageManifests with name %s in namespace %s from catalog"+
 			" %s due to %s", name, nsname, catalog, err.Error())
@@ -151,10 +147,10 @@ func (builder *PackageManifestBuilder) Get() (*operatorv1.PackageManifest, error
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	packageManifest := &operatorv1.PackageManifest{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		packageManifest)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"PackageManifest object %s does not exist in namespace %s",
@@ -176,6 +172,7 @@ func (builder *PackageManifestBuilder) Exists() bool {
 		"Checking if PackageManifest %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -200,7 +197,6 @@ func (builder *PackageManifestBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/olm/packagemanifestlist.go
+++ b/pkg/olm/packagemanifestlist.go
@@ -29,7 +29,6 @@ func ListPackageManifest(
 	}
 
 	err := apiClient.AttachScheme(operatorv1.AddToScheme)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to add packageManifest scheme to client schemes")
 
@@ -53,8 +52,8 @@ func ListPackageManifest(
 	glog.V(100).Infof(logMessage)
 
 	pkgManifestList := new(operatorv1.PackageManifestList)
-	err = apiClient.List(context.TODO(), pkgManifestList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), pkgManifestList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list PackageManifests in the namespace %s due to %s",
 			nsname, err.Error())

--- a/pkg/olm/subscription.go
+++ b/pkg/olm/subscription.go
@@ -179,10 +179,10 @@ func (builder *SubscriptionBuilder) Get() (*operatorsV1alpha1.Subscription, erro
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	subscription := &operatorsV1alpha1.Subscription{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		subscription)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"Subscription object %s does not exist in namespace %s",
@@ -228,6 +228,7 @@ func (builder *SubscriptionBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -252,7 +253,6 @@ func (builder *SubscriptionBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,6 @@ func (builder *SubscriptionBuilder) Update() (*SubscriptionBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}

--- a/pkg/oran/allocatednode.go
+++ b/pkg/oran/allocatednode.go
@@ -84,11 +84,11 @@ func (builder *AllocatedNodeBuilder) Get() (*pluginsv1alpha1.AllocatedNode, erro
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	node := &pluginsv1alpha1.AllocatedNode{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, node)
-
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,6 @@ func (builder *AllocatedNodeBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	object, err := builder.Get()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get AllocatedNode object %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)

--- a/pkg/oran/allocatednodelist.go
+++ b/pkg/oran/allocatednodelist.go
@@ -43,8 +43,8 @@ func ListAllocatedNodes(
 	glog.V(100).Info(logMessage)
 
 	nodeList := new(pluginsv1alpha1.AllocatedNodeList)
-	err = apiClient.List(context.TODO(), nodeList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), nodeList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list AllocatedNodes in all namespaces due to %v", err)
 

--- a/pkg/oran/api/provisioning.go
+++ b/pkg/oran/api/provisioning.go
@@ -297,8 +297,8 @@ func dataFromProvisioningRequest(
 	}
 
 	params := make(map[string]any)
-	err = json.Unmarshal(provisioningRequest.Spec.TemplateParameters.Raw, &params)
 
+	err = json.Unmarshal(provisioningRequest.Spec.TemplateParameters.Raw, &params)
 	if err != nil {
 		return provisioning.ProvisioningRequestData{}, fmt.Errorf("failed to unmarshal TemplateParameters: %w", err)
 	}

--- a/pkg/oran/api/provisioning_test.go
+++ b/pkg/oran/api/provisioning_test.go
@@ -372,6 +372,7 @@ func TestProvisioningClientGroupVersionKindFor(t *testing.T) {
 			validateError: func(t *testing.T, err error) {
 				t.Helper()
 				assert.Error(t, err)
+
 				target := &unimplementedError{}
 				assert.ErrorAs(t, err, &target)
 				assert.Equal(t, ProvisioningClientType, target.clientType)
@@ -410,6 +411,7 @@ func TestProvisioningClientIsObjectNamespaced(t *testing.T) {
 			validateError: func(t *testing.T, err error) {
 				t.Helper()
 				assert.Error(t, err)
+
 				target := &unimplementedError{}
 				assert.ErrorAs(t, err, &target)
 				assert.Equal(t, ProvisioningClientType, target.clientType)

--- a/pkg/oran/clustertemplate.go
+++ b/pkg/oran/clustertemplate.go
@@ -88,11 +88,11 @@ func (builder *ClusterTemplateBuilder) Get() (*provisioningv1alpha1.ClusterTempl
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterTemplate := &provisioningv1alpha1.ClusterTemplate{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, clusterTemplate)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get ClusterTemplate object %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -113,6 +113,7 @@ func (builder *ClusterTemplateBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -140,8 +141,8 @@ func (builder *ClusterTemplateBuilder) WaitForCondition(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Infof("Failed to get ClusterTemplate %s in namespace %s: %v",
 					builder.Definition.Name, builder.Definition.Namespace, err)
@@ -173,7 +174,6 @@ func (builder *ClusterTemplateBuilder) WaitForCondition(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oran/clustertemplatelist.go
+++ b/pkg/oran/clustertemplatelist.go
@@ -43,8 +43,8 @@ func ListClusterTemplates(
 	glog.V(100).Info(logMessage)
 
 	clusterTemplateList := new(provisioningv1alpha1.ClusterTemplateList)
-	err = apiClient.List(context.TODO(), clusterTemplateList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), clusterTemplateList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list ClusterTemplates in all namespaces due to %v", err)
 

--- a/pkg/oran/nodeallocationrequest.go
+++ b/pkg/oran/nodeallocationrequest.go
@@ -84,11 +84,11 @@ func (builder *NARBuilder) Get() (*pluginsv1alpha1.NodeAllocationRequest, error)
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nodeAllocationRequest := &pluginsv1alpha1.NodeAllocationRequest{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nodeAllocationRequest)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get NodeAllocationRequest object %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -109,7 +109,6 @@ func (builder *NARBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	object, err := builder.Get()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get NodeAllocationRequest object %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)

--- a/pkg/oran/nodeallocationrequestlist.go
+++ b/pkg/oran/nodeallocationrequestlist.go
@@ -43,8 +43,8 @@ func ListNodeAllocationRequests(
 	glog.V(100).Info(logMessage)
 
 	nodeAllocationRequestList := new(pluginsv1alpha1.NodeAllocationRequestList)
-	err = apiClient.List(context.TODO(), nodeAllocationRequestList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), nodeAllocationRequestList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list NodeAllocationRequests in all namespaces due to %v", err)
 

--- a/pkg/oran/provisioningrequest.go
+++ b/pkg/oran/provisioningrequest.go
@@ -233,10 +233,10 @@ func (builder *ProvisioningRequestBuilder) Get() (*provisioningv1alpha1.Provisio
 		"Getting ProvisioningRequest object %s", builder.Definition.Name)
 
 	provisioningRequest := &provisioningv1alpha1.ProvisioningRequest{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, provisioningRequest)
-
 	if err != nil {
 		return nil, err
 	}
@@ -253,8 +253,8 @@ func (builder *ProvisioningRequestBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if ProvisioningRequest %s exists", builder.Definition.Name)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("ProvisioningRequest %s does not exist: %v", builder.Definition.Name, err)
 	}
@@ -380,8 +380,8 @@ func (builder *ProvisioningRequestBuilder) WaitForCondition(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Infof("Failed to get ProvisioningRequest %s: %v", builder.Definition.Name, err)
 
@@ -412,7 +412,6 @@ func (builder *ProvisioningRequestBuilder) WaitForCondition(
 
 			return false, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}
@@ -458,8 +457,8 @@ func (builder *ProvisioningRequestBuilder) WaitForPhaseAfter(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Infof("Failed to get ProvisioningRequest %s: %v", builder.Definition.Name, err)
 
@@ -473,7 +472,6 @@ func (builder *ProvisioningRequestBuilder) WaitForPhaseAfter(
 
 			return inPhase && (updatedAfterStart || start.IsZero()), nil
 		})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/pfstatus/pflacpmonitor.go
+++ b/pkg/pfstatus/pflacpmonitor.go
@@ -83,6 +83,7 @@ func (builder *PfStatusConfigurationBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -101,7 +102,6 @@ func (builder *PfStatusConfigurationBuilder) Create() (*PfStatusConfigurationBui
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create pfStatusConfiguration")
 
@@ -157,9 +157,9 @@ func (builder *PfStatusConfigurationBuilder) Get() (*pfstatustypes.PFLACPMonitor
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	pfstatusConfig := &pfstatustypes.PFLACPMonitor{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace}, pfstatusConfig)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"pfStatusConfiguration object %s does not exist in namespace %s",
@@ -242,7 +242,6 @@ func (builder *PfStatusConfigurationBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete pfStatusConfiguration: %w", err)
 	}

--- a/pkg/pod/list.go
+++ b/pkg/pod/list.go
@@ -42,7 +42,6 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	podList, err := apiClient.Pods(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list pods in the nsname %s due to %s", nsname, err.Error())
 
@@ -90,7 +89,6 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	podList, err := apiClient.Pods("").List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list all pods due to %s", err.Error())
 
@@ -130,7 +128,6 @@ func ListByNamePattern(apiClient *clients.Settings, namePattern, nsname string) 
 	}
 
 	podList, err := apiClient.Pods(nsname).List(context.TODO(), metav1.ListOptions{})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list pods filtered by the name pattern %s in the nsname %s due to %s",
 			namePattern, nsname, err.Error())

--- a/pkg/pod/network.go
+++ b/pkg/pod/network.go
@@ -215,6 +215,7 @@ func StaticIPBondAnnotationWithInterface(
 		if staticAnnotation == nil {
 			return nil
 		}
+
 		annotation = append(annotation, staticAnnotation)
 	}
 
@@ -266,10 +267,8 @@ func StaticIPMultiNetDualStackAnnotation(sriovNets, ipAddr []string) ([]*multus.
 func ipValid(ipAddrBond []string) bool {
 	for _, ipAddr := range ipAddrBond {
 		_, err := netip.ParsePrefix(ipAddr)
-
 		if err != nil {
 			_, err = netip.ParseAddr(ipAddr)
-
 			if err != nil {
 				glog.V(100).Infof("The ip address %s in ip address list is invalid", ipAddr)
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -86,7 +86,6 @@ func NewBuilder(apiClient *clients.Settings, name, nsname, image string) *Builde
 	}
 
 	defaultContainer, err := NewContainerBuilder("test", image, []string{"/bin/bash", "-c", "sleep INF"}).GetContainerCfg()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to define the default container settings")
 
@@ -207,7 +206,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 
 	err := builder.apiClient.Pods(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete pod: %w", err)
 	}
@@ -232,7 +230,6 @@ func (builder *Builder) DeleteAndWait(timeout time.Duration) (*Builder, error) {
 	}
 
 	err = builder.WaitUntilDeleted(timeout)
-
 	if err != nil {
 		return builder, err
 	}
@@ -261,7 +258,6 @@ func (builder *Builder) DeleteImmediate() (*Builder, error) {
 
 	err := builder.apiClient.Pods(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Object.Name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))})
-
 	if err != nil {
 		return builder, fmt.Errorf("can not immediately delete pod: %w", err)
 	}
@@ -286,7 +282,6 @@ func (builder *Builder) CreateAndWaitUntilRunning(timeout time.Duration) (*Build
 	}
 
 	err = builder.WaitUntilRunning(timeout)
-
 	if err != nil {
 		return builder, err
 	}
@@ -465,7 +460,6 @@ func (builder *Builder) ExecCommand(command []string, containerName ...string) (
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(builder.apiClient.Config, "POST", req.URL())
-
 	if err != nil {
 		return buffer, err
 	}
@@ -475,7 +469,6 @@ func (builder *Builder) ExecCommand(command []string, containerName ...string) (
 		Stderr: os.Stderr,
 		Tty:    true,
 	})
-
 	if err != nil {
 		return buffer, err
 	}
@@ -546,7 +539,6 @@ func (builder *Builder) ExecCommandWithTimeout(
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(builder.apiClient.Config, "POST", req.URL())
-
 	if err != nil {
 		return buffer, err
 	}
@@ -559,7 +551,6 @@ func (builder *Builder) ExecCommandWithTimeout(
 		Stderr: os.Stderr,
 		Tty:    true,
 	})
-
 	if err != nil {
 		return buffer, err
 	}
@@ -627,7 +618,6 @@ func (builder *Builder) Copy(path, containerName string, tar bool) (bytes.Buffer
 		Proxier:    proxy,
 		PingPeriod: 0,
 	})
-
 	if err != nil {
 		return bytes.Buffer{}, err
 	}
@@ -638,7 +628,6 @@ func (builder *Builder) Copy(path, containerName string, tar bool) (bytes.Buffer
 	}
 
 	exec, err := remotecommand.NewSPDYExecutorForTransports(wrapper, upgradeRoundTripper, "POST", req.URL())
-
 	if err != nil {
 		return buffer, err
 	}
@@ -649,7 +638,6 @@ func (builder *Builder) Copy(path, containerName string, tar bool) (bytes.Buffer
 		Stderr: os.Stderr,
 		Tty:    false,
 	})
-
 	if err != nil {
 		return buffer, err
 	}
@@ -667,6 +655,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Pods(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -972,7 +961,6 @@ func (builder *Builder) WithSecondaryNetwork(network []*multus.NetworkSelectionE
 	}
 
 	netAnnotation, err := json.Marshal(network)
-
 	if err != nil {
 		builder.errorMsg = fmt.Sprintf("error to unmarshal network annotation due to: %s", err.Error())
 
@@ -1114,8 +1102,8 @@ func (builder *Builder) PullImage(timeout time.Duration, testCmd []string) error
 
 	builder.WithRestartPolicy(corev1.RestartPolicyNever)
 	builder.RedefineDefaultCMD(testCmd)
-	_, err := builder.Create()
 
+	_, err := builder.Create()
 	if err != nil {
 		glog.V(100).Infof(
 			"Failed to create pod %s in namespace %s and pull image %s to node: %s",
@@ -1126,7 +1114,6 @@ func (builder *Builder) PullImage(timeout time.Duration, testCmd []string) error
 	}
 
 	statusErr := builder.WaitUntilInStatus(corev1.PodSucceeded, timeout)
-
 	if statusErr != nil {
 		glog.V(100).Infof(
 			"Pod status timeout %s. Pod is not in status Succeeded in namespace %s. "+
@@ -1135,7 +1122,6 @@ func (builder *Builder) PullImage(timeout time.Duration, testCmd []string) error
 			builder.Definition.Spec.NodeName)
 
 		_, err = builder.Delete()
-
 		if err != nil {
 			glog.V(100).Infof(
 				"Failed to remove pod %s in namespace %s from node: %s",
@@ -1209,7 +1195,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/poddisruptionbudget/list.go
+++ b/pkg/poddisruptionbudget/list.go
@@ -81,7 +81,6 @@ func list(apiClient *clients.Settings, nsname string, options metav1.ListOptions
 	}
 
 	pdbList, err := apiClient.PodDisruptionBudgets(nsname).List(context.TODO(), options)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list podDisruptionBudget due to %s", err.Error())
 

--- a/pkg/poddisruptionbudget/poddisruptionbudget.go
+++ b/pkg/poddisruptionbudget/poddisruptionbudget.go
@@ -120,6 +120,7 @@ func (builder *Builder) Create() (*Builder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.PodDisruptionBudgets(
 			builder.Definition.Namespace).Create(context.TODO(),
@@ -149,7 +150,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.PodDisruptionBudgets(builder.Definition.Namespace).Delete(context.TODO(),
 		builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -164,6 +164,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Info("Checking if the PodDisruptionBudget exists in the cluster")
 
 	var err error
+
 	builder.Object, err = builder.apiClient.PodDisruptionBudgets(
 		builder.Definition.Namespace).Get(context.TODO(),
 		builder.Definition.Name,
@@ -203,14 +204,12 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	_, err := builder.apiClient.PodDisruptionBudgets(
 		builder.Definition.Namespace).Update(context.TODO(),
 		builder.Definition, metav1.UpdateOptions{})
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof("Force updating pod disruption budget %s in namespace %s",
 				builder.Definition.Name, builder.Definition.Namespace)
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(msg.FailToUpdateError("pod disruption budget",
 					builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -73,8 +73,8 @@ func (builder *Builder) Get() (*configv1.Proxy, error) {
 	glog.V(100).Infof("Getting proxy object %s", builder.Definition.Name)
 
 	proxy := &configv1.Proxy{}
-	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, proxy)
 
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, proxy)
 	if err != nil {
 		glog.V(100).Infof("Proxy object %s does not exist: %v", builder.Definition.Name, err)
 
@@ -93,6 +93,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if proxy %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/ptp/ptpconfig.go
+++ b/pkg/ptp/ptpconfig.go
@@ -89,8 +89,8 @@ func (builder *PtpConfigBuilder) GetE810Plugin(profileName string) (*E810Plugin,
 
 		if plugin, ok := profile.Plugins["e810"]; ok && plugin != nil {
 			e810Plugin := &E810Plugin{}
-			err := json.Unmarshal(plugin.Raw, e810Plugin)
 
+			err := json.Unmarshal(plugin.Raw, e810Plugin)
 			if err != nil {
 				glog.V(100).Infof("Failed to unmarshal E810 plugin: %v", err)
 
@@ -210,11 +210,11 @@ func (builder *PtpConfigBuilder) Get() (*ptpv1.PtpConfig, error) {
 		"Getting PtpConfig object %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	ptpConfig := &ptpv1.PtpConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, ptpConfig)
-
 	if err != nil {
 		return nil, err
 	}
@@ -232,8 +232,8 @@ func (builder *PtpConfigBuilder) Exists() bool {
 		"Checking if PtpConfig %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to get PtpConfig %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)

--- a/pkg/ptp/ptpconfiglist.go
+++ b/pkg/ptp/ptpconfiglist.go
@@ -43,8 +43,8 @@ func ListPtpConfigs(
 	glog.V(100).Info(logMessage)
 
 	ptpConfigList := new(ptpv1.PtpConfigList)
-	err = apiClient.List(context.TODO(), ptpConfigList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), ptpConfigList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list PtpConfigs in all namespaces due to %v", err)
 

--- a/pkg/ptp/ptpoperatorconfig.go
+++ b/pkg/ptp/ptpoperatorconfig.go
@@ -83,11 +83,11 @@ func (builder *PtpOperatorConfigBuilder) Get() (*ptpv1.PtpOperatorConfig, error)
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	ptpOpConfig := &ptpv1.PtpOperatorConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, ptpOpConfig)
-
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +105,8 @@ func (builder *PtpOperatorConfigBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to get PtpOperatorConfig %s in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -115,7 +115,6 @@ func (builder *ClusterRoleBuilder) WithOptions(options ...ClusterRoleAdditionalO
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -200,7 +199,6 @@ func (builder *ClusterRoleBuilder) Delete() error {
 
 	err := builder.apiClient.ClusterRoles().Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -224,6 +222,7 @@ func (builder *ClusterRoleBuilder) Update() (*ClusterRoleBuilder, error) {
 	}
 
 	var err error
+
 	builder.Object, err = builder.apiClient.ClusterRoles().Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -240,6 +239,7 @@ func (builder *ClusterRoleBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.ClusterRoles().Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 

--- a/pkg/rbac/clusterrolebinding.go
+++ b/pkg/rbac/clusterrolebinding.go
@@ -116,7 +116,6 @@ func (builder *ClusterRoleBindingBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -196,7 +195,6 @@ func (builder *ClusterRoleBindingBuilder) Delete() error {
 
 	err := builder.apiClient.ClusterRoleBindings().Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -216,6 +214,7 @@ func (builder *ClusterRoleBindingBuilder) Update() (*ClusterRoleBindingBuilder, 
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.ClusterRoleBindings().Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -232,6 +231,7 @@ func (builder *ClusterRoleBindingBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.ClusterRoleBindings().Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -135,7 +135,6 @@ func (builder *RoleBuilder) WithOptions(
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -228,7 +227,6 @@ func (builder *RoleBuilder) Delete() error {
 
 	err := builder.apiClient.Roles(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -252,6 +250,7 @@ func (builder *RoleBuilder) Update() (*RoleBuilder, error) {
 	}
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Roles(builder.Definition.Namespace).Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -268,6 +267,7 @@ func (builder *RoleBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Roles(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 

--- a/pkg/rbac/rolebinding.go
+++ b/pkg/rbac/rolebinding.go
@@ -108,6 +108,7 @@ func (builder *RoleBindingBuilder) WithSubjects(subjects []rbacv1.Subject) *Role
 			return builder
 		}
 	}
+
 	builder.Definition.Subjects = append(builder.Definition.Subjects, subjects...)
 
 	return builder
@@ -124,7 +125,6 @@ func (builder *RoleBindingBuilder) WithOptions(options ...RoleBindingAdditionalO
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -227,6 +227,7 @@ func (builder *RoleBindingBuilder) Update() (*RoleBindingBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.RoleBindings(builder.Definition.Namespace).Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -243,6 +244,7 @@ func (builder *RoleBindingBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.RoleBindings(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 

--- a/pkg/replicaset/replicaset.go
+++ b/pkg/replicaset/replicaset.go
@@ -259,6 +259,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.ReplicaSets(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -293,6 +294,7 @@ func (builder *Builder) Update() (*Builder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.ReplicaSets(builder.Definition.Namespace).Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -319,7 +321,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.ReplicaSets(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -351,7 +352,6 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.apiClient.ReplicaSets(builder.Definition.Namespace).Get(
 				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
-
 			if err != nil {
 				return false, nil
 			}
@@ -362,7 +362,6 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 
 			return false, err
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -414,9 +413,9 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 			}
 
 			var err error
+
 			builder.Object, err = builder.apiClient.ReplicaSets(builder.Definition.Namespace).Get(
 				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
-
 			if err != nil {
 				glog.V(100).Infof("Failed to get replicaset from cluster. Error is: '%s'", err.Error())
 

--- a/pkg/reportxml/reportxml.go
+++ b/pkg/reportxml/reportxml.go
@@ -233,7 +233,6 @@ func createNewReportFile(outputFile string, testCases *TestSuite) {
 	encoder.Indent("  ", "    ")
 
 	err = encoder.Encode(testCases)
-
 	if err != nil {
 		panic(fmt.Errorf("failed to dump report to file: %w", err))
 	}
@@ -250,14 +249,13 @@ func appendToExistingReportFile(outputFile string, newReport *TestSuite) {
 	}()
 
 	existingTestSuiteByteFormat, err := os.ReadFile(outputFile)
-
 	if err != nil {
 		panic(fmt.Errorf("failed to read existing report file: %s\n\t%w", outputFile, err))
 	}
 
 	var reportTestSuite *TestSuite
-	err = xml.Unmarshal(existingTestSuiteByteFormat, &reportTestSuite)
 
+	err = xml.Unmarshal(existingTestSuiteByteFormat, &reportTestSuite)
 	if err != nil {
 		panic(fmt.Errorf("failed to unmarshal existing report file: %s\n\t%w", outputFile, err))
 	}
@@ -282,7 +280,6 @@ func appendToExistingReportFile(outputFile string, newReport *TestSuite) {
 	encoder.Indent("  ", "    ")
 
 	err = encoder.Encode(reportTestSuite)
-
 	if err != nil {
 		panic(fmt.Errorf("failed to generate aggregated report\n\t%w", err))
 	}
@@ -319,8 +316,8 @@ func failureMessage(failure types.Failure) string {
 //nolint:gochecknoinits
 func init() {
 	var err error
-	config, err = newConfig()
 
+	config, err = newConfig()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to init reportxml config. Error: %s", err.Error()))
 	}

--- a/pkg/resourcequotas/list.go
+++ b/pkg/resourcequotas/list.go
@@ -36,7 +36,6 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	resourceQuotaList, err := apiClient.ResourceQuotas(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list resource quotas in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/resourcequotas/resourcequotas.go
+++ b/pkg/resourcequotas/resourcequotas.go
@@ -141,14 +141,12 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	_, err := builder.apiClient.ResourceQuotas(
 		builder.Definition.Namespace).Update(context.TODO(),
 		builder.Definition, metav1.UpdateOptions{})
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("resource quota", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(msg.FailToUpdateError("resource quota",
 					builder.Definition.Name, builder.Definition.Namespace))
@@ -223,7 +221,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.ResourceQuotas(builder.Definition.Namespace).Delete(context.TODO(),
 		builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -226,6 +226,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -247,7 +248,6 @@ func (builder *Builder) Get() (*routev1.Route, error) {
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, route)
-
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("cannot delete route: %w", err)
 	}

--- a/pkg/scc/scc.go
+++ b/pkg/scc/scc.go
@@ -536,7 +536,6 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		err = builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create SecurityContextConstraints")
 
@@ -601,8 +600,8 @@ func (builder *Builder) Get() (*securityV1.SecurityContextConstraints, error) {
 	glog.V(100).Infof("Collecting SecurityContextConstraints object %s", builder.Definition.Name)
 
 	scc := &securityV1.SecurityContextConstraints{}
-	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, scc)
 
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{Name: builder.Definition.Name}, scc)
 	if err != nil {
 		glog.V(100).Infof("SecurityContextConstraints object %s does not exist", builder.Definition.Name)
 
@@ -621,8 +620,8 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if SecurityContextConstraints %s exists", builder.Definition.Name)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect SecurityContextConstraints object due to %s", err.Error())
 	}

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -155,7 +155,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.Secrets(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -175,6 +174,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Secrets(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -192,6 +192,7 @@ func (builder *Builder) Update() (*Builder, error) {
 		builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Secrets(builder.Definition.Namespace).Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -287,7 +288,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -284,6 +284,7 @@ func TestSecretWithData(t *testing.T) {
 
 	for _, testCase := range testCases {
 		var runtimeObjects []runtime.Object
+
 		testBuilder, _ := buildTestBuilderWithFakeObjects(runtimeObjects, defaultSecretName, defaultSecretNamespace)
 
 		testBuilder.WithData(testCase.data)

--- a/pkg/service/list.go
+++ b/pkg/service/list.go
@@ -34,7 +34,6 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	serviceList, err := apiClient.Services(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list services in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -160,6 +160,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Services(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -182,7 +183,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.Services(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -202,6 +202,7 @@ func (builder *Builder) Update() (*Builder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Services(builder.Definition.Namespace).Update(
 		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
@@ -219,7 +220,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/serviceaccount/serviceaccount.go
+++ b/pkg/serviceaccount/serviceaccount.go
@@ -150,9 +150,9 @@ func (builder *Builder) CreateToken(duration time.Duration, audiences ...string)
 			ExpirationSeconds: durationSeconds,
 		},
 	}
+
 	tokenRequest, err := builder.apiClient.CreateToken(
 		context.TODO(), builder.Definition.Name, tokenRequest, metav1.CreateOptions{})
-
 	if err != nil {
 		return "", err
 	}
@@ -184,7 +184,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -205,6 +204,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -222,7 +222,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/servicemesh/controlplane.go
+++ b/pkg/servicemesh/controlplane.go
@@ -387,11 +387,11 @@ func (builder *ControlPlaneBuilder) Get() (*istiov2.ServiceMeshControlPlane, err
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	servicemeshcontrolplane := &istiov2.ServiceMeshControlPlane{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, servicemeshcontrolplane)
-
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +440,6 @@ func (builder *ControlPlaneBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete serviceMeshControlPlane %s in namespace %s due to %w",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -461,14 +460,12 @@ func (builder *ControlPlaneBuilder) Update(force bool) (*ControlPlaneBuilder, er
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("serviceMeshControlPlane", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("serviceMeshControlPlane", builder.Definition.Name, builder.Definition.Namespace))
@@ -497,6 +494,7 @@ func (builder *ControlPlaneBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/servicemesh/memberroll.go
+++ b/pkg/servicemesh/memberroll.go
@@ -137,11 +137,11 @@ func (builder *MemberRollBuilder) Get() (*istiov1.ServiceMeshMemberRoll, error) 
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	servicemeshmemberroll := &istiov1.ServiceMeshMemberRoll{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, servicemeshmemberroll)
-
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,6 @@ func (builder *MemberRollBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete serviceMeshMemberRoll %s in namespace %s due to %w",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -209,14 +208,12 @@ func (builder *MemberRollBuilder) Update(force bool) (*MemberRollBuilder, error)
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("serviceMeshMemberRoll", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("serviceMeshMemberRoll", builder.Definition.Name, builder.Definition.Namespace))
@@ -245,6 +242,7 @@ func (builder *MemberRollBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -310,7 +308,6 @@ func (builder *MemberRollBuilder) IsReady(timeout time.Duration) (bool, error) {
 
 			return false, nil
 		})
-
 	if err != nil {
 		return false, fmt.Errorf("the Ready condition did not reached for the Service Mesh MemberRoll %s in "+
 			"namespace %s during %v; %v", builder.Definition.Name, builder.Definition.Namespace, timeout, err)

--- a/pkg/siteconfig/clusterinstance.go
+++ b/pkg/siteconfig/clusterinstance.go
@@ -454,8 +454,8 @@ func (builder *CIBuilder) WaitForCondition(expected metav1.Condition, timeout ti
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Info("failed to get clusterinstance %s/%s: %w",
 					builder.Definition.Namespace, builder.Definition.Name, err)
@@ -511,8 +511,8 @@ func (builder *CIBuilder) WaitForReinstallCondition(expected metav1.Condition,
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Info("failed to get clusterinstance %s/%s: %v",
 					builder.Definition.Namespace, builder.Definition.Name, err)
@@ -575,8 +575,8 @@ func (builder *CIBuilder) WaitForExtraLabel(kind, label string, timeout time.Dur
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder.Object, err = builder.Get()
 
+			builder.Object, err = builder.Get()
 			if err != nil {
 				glog.V(100).Info("Failed to get ClusterInstance %s in namespace %s: %v",
 					builder.Definition.Name, builder.Definition.Namespace, err)
@@ -599,7 +599,6 @@ func (builder *CIBuilder) WaitForExtraLabel(kind, label string, timeout time.Dur
 
 			return exists, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}
@@ -617,11 +616,11 @@ func (builder *CIBuilder) Get() (*siteconfigv1alpha1.ClusterInstance, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	ClusterInstance := &siteconfigv1alpha1.ClusterInstance{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, ClusterInstance)
-
 	if err != nil {
 		return nil, err
 	}
@@ -666,14 +665,12 @@ func (builder *CIBuilder) Update(force bool) (*CIBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("clusterinstance", builder.Definition.Name, builder.Definition.Namespace))
 
 			err := builder.Delete()
-
 			if err != nil {
 				glog.V(100).Infof(
 					msg.FailToUpdateError("clusterinstance", builder.Definition.Name, builder.Definition.Namespace))
@@ -711,7 +708,6 @@ func (builder *CIBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("cannot delete clusterinstance: %w", err)
 	}
@@ -731,6 +727,7 @@ func (builder *CIBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/sriov-fec/clusterconfig.go
+++ b/pkg/sriov-fec/clusterconfig.go
@@ -143,8 +143,8 @@ func (builder *ClusterConfigBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect SriovFecClusterConfig object due to %s", err.Error())
 	}
@@ -184,11 +184,11 @@ func (builder *ClusterConfigBuilder) Get() (*sriovfectypes.SriovFecClusterConfig
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterConfig := &sriovfectypes.SriovFecClusterConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, clusterConfig)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"SriovFecClusterConfig object %s does not exist in namespace %s: %v",
@@ -247,8 +247,8 @@ func (builder *ClusterConfigBuilder) Update(force bool) (*ClusterConfigBuilder, 
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -284,7 +284,6 @@ func (builder *ClusterConfigBuilder) WithOptions(options ...ClusterAdditionalOpt
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/sriov-fec/clusterconfiglist.go
+++ b/pkg/sriov-fec/clusterconfiglist.go
@@ -53,8 +53,8 @@ func ListClusterConfig(
 	passedOptions.Namespace = nsname
 
 	sfncList := new(sriovfectypes.SriovFecClusterConfigList)
-	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovFecClusterConfigs in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/sriov-fec/nodeconfig.go
+++ b/pkg/sriov-fec/nodeconfig.go
@@ -145,8 +145,8 @@ func (builder *NodeConfigBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect SriovFecNodeConfig object due to %s", err.Error())
 	}
@@ -186,11 +186,11 @@ func (builder *NodeConfigBuilder) Get() (*sriovfectypes.SriovFecNodeConfig, erro
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nodeConfig := &sriovfectypes.SriovFecNodeConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nodeConfig)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"SriovFecNodeConfig object %s does not exist in namespace %s: %v",
@@ -249,8 +249,8 @@ func (builder *NodeConfigBuilder) Update(force bool) (*NodeConfigBuilder, error)
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -286,7 +286,6 @@ func (builder *NodeConfigBuilder) WithOptions(options ...AdditionalOptions) *Nod
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/sriov-fec/nodeconfiglist.go
+++ b/pkg/sriov-fec/nodeconfiglist.go
@@ -48,8 +48,8 @@ func List(apiClient *clients.Settings, nsname string, options ...client.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	sfncList := new(sriovfectypes.SriovFecNodeConfigList)
-	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovFecNodeConfigs in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/sriov-vrb/clusterconfig.go
+++ b/pkg/sriov-vrb/clusterconfig.go
@@ -143,8 +143,8 @@ func (builder *ClusterConfigBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect SriovVrbClusterConfig object due to %s", err.Error())
 	}
@@ -184,11 +184,11 @@ func (builder *ClusterConfigBuilder) Get() (*sriovvrbtypes.SriovVrbClusterConfig
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nodeConfig := &sriovvrbtypes.SriovVrbClusterConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nodeConfig)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"SriovVrbClusterConfig object %s does not exist in namespace %s: %v",
@@ -247,8 +247,8 @@ func (builder *ClusterConfigBuilder) Update(force bool) (*ClusterConfigBuilder, 
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -284,7 +284,6 @@ func (builder *ClusterConfigBuilder) WithOptions(options ...ClusterAdditionalOpt
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/sriov-vrb/clusterconfiglist.go
+++ b/pkg/sriov-vrb/clusterconfiglist.go
@@ -53,8 +53,8 @@ func ListClusterConfig(
 	passedOptions.Namespace = nsname
 
 	sfncList := new(sriovvrbtypes.SriovVrbClusterConfigList)
-	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovVrbClusterConfigs in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/sriov-vrb/nodeconfig.go
+++ b/pkg/sriov-vrb/nodeconfig.go
@@ -143,8 +143,8 @@ func (builder *NodeConfigBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
-	builder.Object, err = builder.Get()
 
+	builder.Object, err = builder.Get()
 	if err != nil {
 		glog.V(100).Infof("Failed to collect sriovVrbNodeConfig object due to %s", err.Error())
 	}
@@ -184,11 +184,11 @@ func (builder *NodeConfigBuilder) Get() (*sriovvrbtypes.SriovVrbNodeConfig, erro
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nodeConfig := &sriovvrbtypes.SriovVrbNodeConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, nodeConfig)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"SriovVrbNodeConfig object %s does not exist in namespace %s: %v",
@@ -247,8 +247,8 @@ func (builder *NodeConfigBuilder) Update(force bool) (*NodeConfigBuilder, error)
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		if force {
 			glog.V(100).Infof(
@@ -284,7 +284,6 @@ func (builder *NodeConfigBuilder) WithOptions(options ...NodeAdditionalOptions) 
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 

--- a/pkg/sriov-vrb/nodeconfiglist.go
+++ b/pkg/sriov-vrb/nodeconfiglist.go
@@ -53,8 +53,8 @@ func ListNodeConfig(
 	passedOptions.Namespace = nsname
 
 	sfncList := new(sriovvrbtypes.SriovVrbNodeConfigList)
-	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), sfncList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovVrbNodeConfigs in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/sriov/network.go
+++ b/pkg/sriov/network.go
@@ -289,7 +289,6 @@ func (builder *NetworkBuilder) WithOptions(options ...NetworkAdditionalOptions) 
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -362,10 +361,10 @@ func (builder *NetworkBuilder) Get() (*srIovV1.SriovNetwork, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	network := &srIovV1.SriovNetwork{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		network)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"SriovNetwork object %s does not exist in namespace %s",
@@ -385,7 +384,6 @@ func (builder *NetworkBuilder) Create() (*NetworkBuilder, error) {
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create SriovNetwork")
 
@@ -413,7 +411,6 @@ func (builder *NetworkBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}
@@ -453,7 +450,6 @@ func (builder *NetworkBuilder) WaitUntilDeleted(timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			_, err := builder.Get()
-
 			if err == nil {
 				glog.V(100).Infof("SrIovNetwork %s/%s still present", builder.Definition.Name, builder.Definition.Namespace)
 
@@ -483,6 +479,7 @@ func (builder *NetworkBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -503,7 +500,6 @@ func (builder *NetworkBuilder) Update(force bool) (*NetworkBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	} else if force {
@@ -511,7 +507,6 @@ func (builder *NetworkBuilder) Update(force bool) (*NetworkBuilder, error) {
 			msg.FailToUpdateNotification("SrIovNetwork", builder.Definition.Name, builder.Definition.Namespace))
 
 		err = builder.Delete()
-
 		if err != nil {
 			glog.V(100).Infof(
 				msg.FailToUpdateError("SrIovNetwork", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/sriov/networklist.go
+++ b/pkg/sriov/networklist.go
@@ -48,8 +48,8 @@ func List(apiClient *clients.Settings, nsname string, options ...client.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	networkList := new(srIovV1.SriovNetworkList)
-	err = apiClient.List(context.TODO(), networkList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), networkList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list sriov networks in the namespace %s due to %s", nsname, err.Error())
 
@@ -94,7 +94,6 @@ func CleanAllNetworksByTargetNamespace(
 	}
 
 	networks, err := List(apiClient, operatornsname, options...)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list sriov networks in namespace: %s", operatornsname)
 

--- a/pkg/sriov/networknodestate.go
+++ b/pkg/sriov/networknodestate.go
@@ -82,9 +82,9 @@ func (builder *NetworkNodeStateBuilder) Discover() error {
 		builder.nsName, builder.nodeName)
 
 	nodeNetworkState := &srIovV1.SriovNetworkNodeState{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.nodeName, Namespace: builder.nsName}, nodeNetworkState)
-
 	if err == nil {
 		builder.Objects = nodeNetworkState
 	}
@@ -99,8 +99,8 @@ func (builder *NetworkNodeStateBuilder) GetUpNICs() (srIovV1.InterfaceExts, erro
 	}
 
 	glog.V(100).Infof("Collection of sriov interfaces in UP state for node %s", builder.nodeName)
-	sriovNics, err := builder.GetNICs()
 
+	sriovNics, err := builder.GetNICs()
 	if err != nil {
 		glog.V(100).Infof("Error to discover sriov interfaces for node %s", builder.nodeName)
 
@@ -160,7 +160,6 @@ func (builder *NetworkNodeStateBuilder) WaitUntilSyncStatus(syncStatus string, t
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			err := builder.Discover()
-
 			if err != nil {
 				return false, nil
 			}

--- a/pkg/sriov/networknodestatelist.go
+++ b/pkg/sriov/networknodestatelist.go
@@ -50,8 +50,8 @@ func ListNetworkNodeState(
 	glog.V(100).Infof(logMessage)
 
 	networkNodeStateList := new(srIovV1.SriovNetworkNodeStateList)
-	err = apiClient.List(context.TODO(), networkNodeStateList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), networkNodeStateList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkNodeStates in the namespace %s due to %s", nsname, err.Error())
 

--- a/pkg/sriov/operatorconfig.go
+++ b/pkg/sriov/operatorconfig.go
@@ -86,7 +86,6 @@ func (builder *OperatorConfigBuilder) Create() (*OperatorConfigBuilder, error) {
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create the SriovOperatorConfig")
 
@@ -152,10 +151,10 @@ func (builder *OperatorConfigBuilder) Get() (*srIovV1.SriovOperatorConfig, error
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	operatorConfig := &srIovV1.SriovOperatorConfig{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		operatorConfig)
-
 	if err != nil {
 		glog.V(100).Infof("SriovOperatorConfig object %s does not exist in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)
@@ -176,6 +175,7 @@ func (builder *OperatorConfigBuilder) Exists() bool {
 		"Checking if SriovOperatorConfig %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -297,7 +297,6 @@ func (builder *OperatorConfigBuilder) Update() (*OperatorConfigBuilder, error) {
 	)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}

--- a/pkg/sriov/policy.go
+++ b/pkg/sriov/policy.go
@@ -233,7 +233,6 @@ func (builder *PolicyBuilder) WithOptions(options ...PolicyAdditionalOptions) *P
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -306,10 +305,10 @@ func (builder *PolicyBuilder) Get() (*srIovV1.SriovNetworkNodePolicy, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	nodePolicy := &srIovV1.SriovNetworkNodePolicy{}
+
 	err := builder.apiClient.Get(context.TODO(),
 		runtimeClient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
 		nodePolicy)
-
 	if err != nil {
 		glog.V(100).Infof(
 			"SriovNetworkNodePolicy object %s does not exist in namespace %s",
@@ -329,7 +328,6 @@ func (builder *PolicyBuilder) Create() (*PolicyBuilder, error) {
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +354,6 @@ func (builder *PolicyBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}
@@ -375,6 +372,7 @@ func (builder *PolicyBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if SriovNetworkNodePolicy %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)

--- a/pkg/sriov/policylist.go
+++ b/pkg/sriov/policylist.go
@@ -49,8 +49,8 @@ func ListPolicy(apiClient *clients.Settings, nsname string, options ...client.Li
 	glog.V(100).Infof(logMessage)
 
 	networkNodePoliciesList := new(srIovV1.SriovNetworkNodePolicyList)
-	err = apiClient.List(context.TODO(), networkNodePoliciesList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), networkNodePoliciesList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkNodePolicies in the namespace %s due to %s",
 			nsname, err.Error())
@@ -85,7 +85,6 @@ func CleanAllNetworkNodePolicies(
 	}
 
 	policies, err := ListPolicy(apiClient, operatornsname, options...)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkNodePolicies in namespace: %s", operatornsname)
 
@@ -96,7 +95,6 @@ func CleanAllNetworkNodePolicies(
 		// The "default" SriovNetworkNodePolicy is both mandatory and the default option.
 		if policy.Object.Name != "default" {
 			err = policy.Delete()
-
 			if err != nil {
 				glog.V(100).Infof("Failed to delete SriovNetworkNodePolicy: %s", policy.Object.Name)
 

--- a/pkg/sriov/poolconfig.go
+++ b/pkg/sriov/poolconfig.go
@@ -86,7 +86,6 @@ func (builder *PoolConfigBuilder) Create() (*PoolConfigBuilder, error) {
 
 	if !builder.Exists() {
 		err := builder.apiClient.Create(context.TODO(), builder.Definition)
-
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +115,6 @@ func (builder *PoolConfigBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return err
 	}
@@ -136,6 +134,7 @@ func (builder *PoolConfigBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -152,11 +151,11 @@ func (builder *PoolConfigBuilder) Get() (*srIovV1.SriovNetworkPoolConfig, error)
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	poolConfig := &srIovV1.SriovNetworkPoolConfig{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, poolConfig)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get SriovNetworkPoolConfig %s in namespace %s", builder.Definition.Name,
 			builder.Definition.Namespace)
@@ -177,7 +176,6 @@ func (builder *PoolConfigBuilder) Update() (*PoolConfigBuilder, error) {
 		builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to update SriovNetworkPoolConfig %s in namespace %s", builder.Definition.Name,
 			builder.Definition.Namespace)

--- a/pkg/sriov/poolconfiglist.go
+++ b/pkg/sriov/poolconfiglist.go
@@ -34,7 +34,6 @@ func ListPoolConfigs(apiClient *clients.Settings, namespace string) ([]*PoolConf
 	}
 
 	err = apiClient.List(context.TODO(), sriovNetworkPoolConfigList, &client.ListOptions{Namespace: namespace})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkPoolConfigs in namespace: %s due to %s",
 			namespace, err.Error())
@@ -70,7 +69,6 @@ func CleanAllPoolConfigs(
 	}
 
 	poolConfigs, err := ListPoolConfigs(apiClient, operatornsname)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkPoolConfigs in namespace: %s", operatornsname)
 
@@ -79,7 +77,6 @@ func CleanAllPoolConfigs(
 
 	for _, poolConfig := range poolConfigs {
 		err = poolConfig.Delete()
-
 		if err != nil {
 			glog.V(100).Infof("Failed to delete SriovNetworkPoolConfigs: %s", poolConfig.Object.Name)
 

--- a/pkg/statefulset/list.go
+++ b/pkg/statefulset/list.go
@@ -34,7 +34,6 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	statefulsetList, err := apiClient.StatefulSets(nsname).List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list statefulsets in the namespace %s due to %s", nsname, err.Error())
 
@@ -76,7 +75,6 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	statefulsetList, err := apiClient.StatefulSets("").List(context.TODO(), passedOptions)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list statefulsets in all namespaces due to %s", err.Error())
 

--- a/pkg/statefulset/statefulset.go
+++ b/pkg/statefulset/statefulset.go
@@ -131,7 +131,6 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -237,6 +236,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.StatefulSets(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -261,7 +261,6 @@ func (builder *Builder) Delete() error {
 
 	err := builder.apiClient.StatefulSets(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -287,9 +286,9 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
+
 			builder.Object, err = builder.apiClient.StatefulSets(builder.Definition.Namespace).Get(
 				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
-
 			if err != nil {
 				return false, err
 			}

--- a/pkg/storage/objectbucketclaim.go
+++ b/pkg/storage/objectbucketclaim.go
@@ -133,11 +133,11 @@ func (builder *ObjectBucketClaimBuilder) Get() (*noobaav1alpha1.ObjectBucketClai
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	objectBucketClaimObj := &noobaav1alpha1.ObjectBucketClaim{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, objectBucketClaimObj)
-
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,6 @@ func (builder *ObjectBucketClaimBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete objectBucketClaim: %w", err)
 	}
@@ -205,6 +204,7 @@ func (builder *ObjectBucketClaimBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -220,7 +220,6 @@ func (builder *ObjectBucketClaimBuilder) Update() (*ObjectBucketClaimBuilder, er
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("objectBucketClaim", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/storage/ocs.go
+++ b/pkg/storage/ocs.go
@@ -134,11 +134,11 @@ func (builder *StorageClusterBuilder) Get() (*ocsoperatorv1.StorageCluster, erro
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	storageClusterObj := &ocsoperatorv1.StorageCluster{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, storageClusterObj)
-
 	if err != nil {
 		glog.V(100).Infof("storageCluster object %s does not exist in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)
@@ -159,6 +159,7 @@ func (builder *StorageClusterBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -205,7 +206,6 @@ func (builder *StorageClusterBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete storageCluster: %w", err)
 	}
@@ -230,7 +230,6 @@ func (builder *StorageClusterBuilder) Update() (*StorageClusterBuilder, error) {
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err != nil {
 		glog.V(100).Infof(
 			msg.FailToUpdateError("storageCluster", builder.Definition.Name, builder.Definition.Namespace))

--- a/pkg/storage/odf.go
+++ b/pkg/storage/odf.go
@@ -135,11 +135,11 @@ func (builder *SystemODFBuilder) Get() (*odfoperatorv1alpha1.StorageSystem, erro
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	storageSystemObj := &odfoperatorv1alpha1.StorageSystem{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, storageSystemObj)
-
 	if err != nil {
 		glog.V(100).Infof("failed to find SystemODF object %s in namespace %s",
 			builder.Definition.Name, builder.Definition.Namespace)
@@ -160,6 +160,7 @@ func (builder *SystemODFBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -206,7 +207,6 @@ func (builder *SystemODFBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete SystemODF: %w", err)
 	}

--- a/pkg/storage/pv.go
+++ b/pkg/storage/pv.go
@@ -71,6 +71,7 @@ func (builder *PVBuilder) Exists() bool {
 	glog.V(100).Infof("Checking if PersistentVolume %s exists", builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.PersistentVolumes().Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 

--- a/pkg/storage/pvc.go
+++ b/pkg/storage/pvc.go
@@ -225,7 +225,6 @@ func (builder *PVCBuilder) Delete() error {
 
 	err := builder.apiClient.PersistentVolumeClaims(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to delete PersistentVolumeClaim %s from %s namespace",
 			builder.Definition.Name, builder.Definition.Namespace)
@@ -330,6 +329,7 @@ func (builder *PVCBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.PersistentVolumeClaims(builder.Definition.Namespace).Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 

--- a/pkg/storage/storageclass.go
+++ b/pkg/storage/storageclass.go
@@ -154,7 +154,6 @@ func (builder *ClassBuilder) WithOptions(options ...AdditionalOptions) *ClassBui
 	for _, option := range options {
 		if option != nil {
 			builder, err := option(builder)
-
 			if err != nil {
 				glog.V(100).Infof("Error occurred in mutation function")
 
@@ -214,6 +213,7 @@ func (builder *ClassBuilder) Exists() bool {
 		builder.Definition.Name)
 
 	var err error
+
 	builder.Object, err = builder.apiClient.StorageClasses().Get(
 		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
@@ -255,7 +255,6 @@ func (builder *ClassBuilder) Delete() error {
 
 	err := builder.apiClient.StorageClasses().Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -328,9 +327,9 @@ func (builder *ClassBuilder) Update(force bool) (*ClassBuilder, error) {
 	}
 
 	var err error
+
 	builder.Object, err = builder.apiClient.StorageClasses().
 		Update(context.TODO(), builder.Definition, metav1.UpdateOptions{})
-
 	if err != nil {
 		if force {
 			glog.V(100).Infof(

--- a/pkg/velero/backup.go
+++ b/pkg/velero/backup.go
@@ -276,10 +276,10 @@ func (builder *BackupBuilder) Get() (*velerov1.Backup, error) {
 	glog.V(100).Infof("Collecting Backup object %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
 
 	backup := &velerov1.Backup{}
+
 	err := builder.apiClient.Get(
 		context.TODO(),
 		goclient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace}, backup)
-
 	if err != nil {
 		glog.V(100).Infof("Backup object %s does not exist in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -300,6 +300,7 @@ func (builder *BackupBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -341,8 +342,8 @@ func (builder *BackupBuilder) Update() (*BackupBuilder, error) {
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -369,7 +370,6 @@ func (builder *BackupBuilder) Delete() (*BackupBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete backup: %w", err)
 	}

--- a/pkg/velero/backupstoragelocation.go
+++ b/pkg/velero/backupstoragelocation.go
@@ -175,20 +175,19 @@ func (builder *BackupStorageLocationBuilder) WaitUntilAvailable(
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			glog.V(100).Infof("Waiting for the backupstoragelocation %s in %s to become available",
 				builder.Definition.Name, builder.Definition.Namespace)
 
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, err
 			}
 
 			return builder.Object.Status.Phase == velerov1.BackupStorageLocationPhaseAvailable, nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -208,20 +207,19 @@ func (builder *BackupStorageLocationBuilder) WaitUntilUnavailable(
 	}
 
 	var err error
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			glog.V(100).Infof("Waiting for the backupstoragelocation %s in %s to become unavailable",
 				builder.Definition.Name, builder.Definition.Namespace)
 
 			builder.Object, err = builder.Get()
-
 			if err != nil {
 				return false, err
 			}
 
 			return builder.Object.Status.Phase == velerov1.BackupStorageLocationPhaseUnavailable, nil
 		})
-
 	if err == nil {
 		return builder, nil
 	}
@@ -238,10 +236,10 @@ func (builder *BackupStorageLocationBuilder) Get() (*velerov1.BackupStorageLocat
 	glog.V(100).Infof("Collecting BackupStorageLocation object %s", builder.Definition.Name)
 
 	backupStorageLocation := &velerov1.BackupStorageLocation{}
+
 	err := builder.apiClient.Get(
 		context.TODO(),
 		goclient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace}, backupStorageLocation)
-
 	if err != nil {
 		glog.V(100).Infof("BackupStorageLocation object %s does not exist", builder.Definition.Name)
 
@@ -261,6 +259,7 @@ func (builder *BackupStorageLocationBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -301,7 +300,6 @@ func (builder *BackupStorageLocationBuilder) Update() (*BackupStorageLocationBui
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
-
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -328,7 +326,6 @@ func (builder *BackupStorageLocationBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return fmt.Errorf("can not delete backupstoragelocation: %w", err)
 	}

--- a/pkg/velero/backupstoragelocation_test.go
+++ b/pkg/velero/backupstoragelocation_test.go
@@ -545,6 +545,7 @@ func generateBackupStorageLocationBuilderWithFakeObjects(objects []runtime.Objec
 
 func generateBackupStorageLocationBuilder() *BackupStorageLocationBuilder {
 	var runtimeObjects []runtime.Object
+
 	runtimeObjects = append(runtimeObjects, generateBackupStorageLocation())
 
 	return &BackupStorageLocationBuilder{

--- a/pkg/velero/backupstoragelocationlist.go
+++ b/pkg/velero/backupstoragelocationlist.go
@@ -47,8 +47,8 @@ func ListBackupStorageLocationBuilder(
 	glog.V(100).Infof(logMessage)
 
 	bslList := &velerov1.BackupStorageLocationList{}
-	err = apiClient.List(context.TODO(), bslList, &passedOptions)
 
+	err = apiClient.List(context.TODO(), bslList, &passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list backupstoragelocations in the nsname %s due to %s", nsname, err.Error())
 

--- a/pkg/velero/restore.go
+++ b/pkg/velero/restore.go
@@ -169,10 +169,10 @@ func (builder *RestoreBuilder) Get() (*velerov1.Restore, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	restore := &velerov1.Restore{}
+
 	err := builder.apiClient.Get(
 		context.TODO(),
 		goclient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace}, restore)
-
 	if err != nil {
 		glog.V(100).Infof("Restore object %s does not exist in namespace %s: %v",
 			builder.Definition.Name, builder.Definition.Namespace, err)
@@ -193,6 +193,7 @@ func (builder *RestoreBuilder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -234,8 +235,8 @@ func (builder *RestoreBuilder) Update() (*RestoreBuilder, error) {
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err == nil {
 		builder.Object = builder.Definition
 	}
@@ -263,7 +264,6 @@ func (builder *RestoreBuilder) Delete() (*RestoreBuilder, error) {
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
-
 	if err != nil {
 		return builder, fmt.Errorf("can not delete restore: %w", err)
 	}

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -76,6 +76,7 @@ func (builder *MutatingConfigurationBuilder) Exists() bool {
 	}
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -88,10 +89,10 @@ func (builder *MutatingConfigurationBuilder) Get() (*admregv1.MutatingWebhookCon
 	}
 
 	mutatingWebhookConfiguration := &admregv1.MutatingWebhookConfiguration{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, mutatingWebhookConfiguration)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get MutatingWebhookConfiguration %s: %v", builder.Definition.Name, err)
 
@@ -144,8 +145,8 @@ func (builder *MutatingConfigurationBuilder) Update() (*MutatingConfigurationBui
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		return builder, err
 	}

--- a/pkg/webhook/validatingwebhook.go
+++ b/pkg/webhook/validatingwebhook.go
@@ -76,6 +76,7 @@ func (builder *ValidatingConfigurationBuilder) Exists() bool {
 	}
 
 	var err error
+
 	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
@@ -88,10 +89,10 @@ func (builder *ValidatingConfigurationBuilder) Get() (*admregv1.ValidatingWebhoo
 	}
 
 	validatingWebhookConfiguration := &admregv1.ValidatingWebhookConfiguration{}
+
 	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name: builder.Definition.Name,
 	}, validatingWebhookConfiguration)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get ValidatingWebhookConfiguration %s: %v", builder.Definition.Name, err)
 
@@ -144,8 +145,8 @@ func (builder *ValidatingConfigurationBuilder) Update() (*ValidatingConfiguratio
 	}
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 	if err != nil {
 		return builder, err
 	}

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -58,7 +58,7 @@ function RunGolangCiLint() {
 
 	echo "Running golangci-lint"
 
-	if golangci-lint run -v; then
+	if golangci-lint run -v --max-issues-per-linter=0 --max-same-issues=0; then
 		return 0;
 	fi
 

--- a/usage/icsp/icsp.go
+++ b/usage/icsp/icsp.go
@@ -31,7 +31,6 @@ func main() {
 	_, err = icspbuilder.WithRepositoryDigestMirror(
 		"newsource",
 		[]string{"Mirror1.io", "Mirror2.io", "Mirror3.io"}).Update()
-
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Similar to: https://github.com/rh-ecosystem-edge/eco-gotests/pull/729

If we want, we can re-enable the wsl_v5 linter in another PR but there are a bunch of in-code changes associated with it.

Linter configuration updates:

* Updated the Go version used by the linter from `1.24` to `1.25` to match the project's current Go version.
* Temporarily disabled the `wsl` (whitespace-stylistic) linter by commenting it out, along with its configuration, due to high noise in its output. [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L43-R44) [[2]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L126-R132)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting toolchain to use Go 1.25.
  * Adjusted linter configuration, temporarily disabling a noisy whitespace linter.
  * Added commented template for a future linter configuration to streamline upgrades.
  * No impact on application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->