### PR TITLE
coderabbit: fix path filters

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,7 +27,7 @@ reviews:
   in_progress_fortune: true
   poem: false
   labeling_instructions: []
-  path_filters: ['!vendor/', '!pkg/schemes/']
+  path_filters: ['!vendor/**', '!pkg/schemes/**']
   path_instructions: []
   abort_on_close: true
   disable_cache: false


### PR DESCRIPTION
Without adding the double asterisks at the end it will not ignore all files under a directory.