### PR TITLE
bmh: add HardwareData builder

### DIFF
--- a/pkg/bmh/hardwaredata.go
+++ b/pkg/bmh/hardwaredata.go
@@ -1,0 +1,34 @@
+package bmh
+
+import (
+	"context"
+
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HardwareDataBuilder provides a struct for the HardwareData resource containing a connection to the cluster and the
+// HardwareData definition.
+type HardwareDataBuilder struct {
+	common.EmbeddableBuilder[bmhv1alpha1.HardwareData, *bmhv1alpha1.HardwareData]
+}
+
+// GetGVK returns the HardwareData GVK for this builder.
+func (builder *HardwareDataBuilder) GetGVK() schema.GroupVersionKind {
+	return bmhv1alpha1.GroupVersion.WithKind("HardwareData")
+}
+
+// PullHardwareData fetches an existing HardwareData from the cluster by name and namespace.
+func PullHardwareData(apiClient *clients.Settings, name, nsname string) (*HardwareDataBuilder, error) {
+	return common.PullNamespacedBuilder[bmhv1alpha1.HardwareData, HardwareDataBuilder](
+		context.TODO(), apiClient, bmhv1alpha1.AddToScheme, name, nsname)
+}
+
+// ListHardwareData returns all HardwareData CRs across all namespaces.
+func ListHardwareData(apiClient *clients.Settings, options ...runtimeclient.ListOption) ([]*HardwareDataBuilder, error) {
+	return common.List[bmhv1alpha1.HardwareData, bmhv1alpha1.HardwareDataList, HardwareDataBuilder](
+		context.TODO(), apiClient, bmhv1alpha1.AddToScheme, options...)
+}

--- a/pkg/bmh/hardwaredata_test.go
+++ b/pkg/bmh/hardwaredata_test.go
@@ -1,0 +1,45 @@
+package bmh
+
+import (
+	"testing"
+
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
+)
+
+var hardwareDataGVK = bmhv1alpha1.GroupVersion.WithKind("HardwareData")
+
+func TestPullHardwareData(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewNamespacedPullTestConfig(
+		PullHardwareData,
+		bmhv1alpha1.AddToScheme,
+		hardwareDataGVK,
+	).ExecuteTests(t)
+}
+
+func TestListHardwareData(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewListTestConfig(
+		ListHardwareData,
+		bmhv1alpha1.AddToScheme,
+		hardwareDataGVK,
+	).ExecuteTests(t)
+}
+
+func TestHardwareDataMethods(t *testing.T) {
+	t.Parallel()
+
+	commonTestConfig := testhelper.NewCommonTestConfig[bmhv1alpha1.HardwareData, HardwareDataBuilder](
+		bmhv1alpha1.AddToScheme,
+		hardwareDataGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
+
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		Run(t)
+}


### PR DESCRIPTION
This commit leverages the common builder to introduce a builder for the HardwareData CR, part of Metal^3. This builder is implemented with just the read-only methods and listing. All functions are unit tested.

Assisted-by: Cursor