### PR TITLE
oran api: add constructor for raw filters

### DIFF
--- a/pkg/oran/api/filter/filter.go
+++ b/pkg/oran/api/filter/filter.go
@@ -129,6 +129,13 @@ func And(filters ...Filter) *andFilter {
 	return (*andFilter)(&filters)
 }
 
+// Raw returns a filter from the given string without validation. The caller accepts the risk that the
+// filter may be malformed or rejected by the API. Prefer the typed constructors when building filters
+// for production use.
+func Raw(s string) *rawFilter {
+	return &rawFilter{value: s}
+}
+
 // basicFilter is a filter that contains only a single operator with its associated field and value(s).
 type basicFilter struct {
 	Operator FilterOperator
@@ -168,6 +175,19 @@ func (f *basicFilter) Filter() string {
 	builder.WriteByte(')')
 
 	return builder.String()
+}
+
+// rawFilter is a filter string used verbatim. It is not validated and may be malformed.
+type rawFilter struct {
+	value string
+}
+
+// Assert at compile time that rawFilter implements the Filter interface.
+var _ Filter = (*rawFilter)(nil)
+
+// Filter returns the raw filter string.
+func (f *rawFilter) Filter() string {
+	return f.value
 }
 
 // andFilter is a filter that contains multiple filters, all of which must match. It can compose basicFilters and other

--- a/pkg/oran/api/filter/filter_test.go
+++ b/pkg/oran/api/filter/filter_test.go
@@ -85,6 +85,13 @@ func TestAnd(t *testing.T) {
 	assert.Equal(t, "(eq,field1,value1);(cont,field2,value2)", andFilter.Filter())
 }
 
+func TestRaw(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "(eq,field,value)", Raw("(eq,field,value)").Filter())
+	assert.Equal(t, "not-a-valid-filter", Raw("not-a-valid-filter").Filter())
+}
+
 func TestBasicFilterWithSpecialCharacters(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This commit introduces a constructor for filter.Filter which allows specifying a string to use as the filter directly. It is designed mainly for tests which need to have an intentionally invalid filter. Otherwise, by using the constructor, callers lose the guarantee that the filter is valid and will not be rejected by the API.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying filter expressions exactly as entered, without validation or transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->