### PR TITLE
ocm: split O-RAN eligibility into 2 functions

### DIFF
--- a/pkg/ocm/managedclusterlist.go
+++ b/pkg/ocm/managedclusterlist.go
@@ -65,33 +65,57 @@ func ListManagedClusters(apiClient *clients.Settings, options ...runtimeclient.L
 	return managedClusterObjects, nil
 }
 
-// ListORANEligibleManagedClusters returns ManagedClusters that match the O2IMS node cluster collector criteria.
-func ListORANEligibleManagedClusters(
+// ListNodeClusterEligibleManagedClusters returns ManagedClusters eligible for the cluster API (NodeCluster): available
+// (ManagedClusterConditionAvailable is not nil or False), provisioned for spokes
+// (clustertemplates.clcm.openshift.io/templateId label is present; the hub cluster is exempt), and convertible (vendor
+// and clusterID labels are present, clusterID is a valid UUID, and openshiftVersion is present when vendor is
+// OpenShift).
+func ListNodeClusterEligibleManagedClusters(
 	apiClient *clients.Settings, options ...runtimeclient.ListOption) ([]*ManagedClusterBuilder, error) {
 	managedClusters, err := ListManagedClusters(apiClient, options...)
 	if err != nil {
 		return nil, err
 	}
 
-	var eligibleManagedClusters []*ManagedClusterBuilder
+	return filterEligibleManagedClusters(managedClusters, IsNodeClusterEligibleManagedCluster), nil
+}
+
+// ListDeploymentManagerEligibleManagedClusters returns ManagedClusters eligible for the inventory API
+// (DeploymentManager): available (ManagedClusterConditionAvailable is not nil or False), provisioned
+// (clustertemplates.clcm.openshift.io/templateId label is present), labeled with clusterID, and exposing a non-empty
+// client URL in ManagedClusterClientConfigs.
+func ListDeploymentManagerEligibleManagedClusters(
+	apiClient *clients.Settings, options ...runtimeclient.ListOption) ([]*ManagedClusterBuilder, error) {
+	managedClusters, err := ListManagedClusters(apiClient, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return filterEligibleManagedClusters(managedClusters, IsDeploymentManagerEligibleManagedCluster), nil
+}
+
+func filterEligibleManagedClusters(
+	managedClusters []*ManagedClusterBuilder,
+	isEligible func(*clusterv1.ManagedCluster) bool,
+) []*ManagedClusterBuilder {
+	eligibleManagedClusters := make([]*ManagedClusterBuilder, 0, len(managedClusters))
 
 	for _, managedCluster := range managedClusters {
-		if IsORANEligibleManagedCluster(managedCluster.Definition) {
+		if isEligible(managedCluster.Definition) {
 			eligibleManagedClusters = append(eligibleManagedClusters, managedCluster)
 		}
 	}
 
-	return eligibleManagedClusters, nil
+	return eligibleManagedClusters
 }
 
-// IsORANEligibleManagedCluster reports whether a ManagedCluster would be ingested by the O2IMS cluster collector.
-func IsORANEligibleManagedCluster(cluster *clusterv1.ManagedCluster) bool {
+// IsNodeClusterEligibleManagedCluster reports whether a ManagedCluster is eligible for the cluster API (NodeCluster).
+func IsNodeClusterEligibleManagedCluster(cluster *clusterv1.ManagedCluster) bool {
 	if cluster == nil {
 		return false
 	}
 
-	condition := meta.FindStatusCondition(cluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
-	if condition == nil || condition.Status == metav1.ConditionFalse {
+	if !isManagedClusterAvailable(cluster) {
 		return false
 	}
 
@@ -106,6 +130,52 @@ func IsORANEligibleManagedCluster(cluster *clusterv1.ManagedCluster) bool {
 	}
 
 	return canConvertManagedClusterToNodeCluster(cluster)
+}
+
+// IsDeploymentManagerEligibleManagedCluster reports whether a ManagedCluster is eligible for the inventory API
+// (DeploymentManager).
+func IsDeploymentManagerEligibleManagedCluster(cluster *clusterv1.ManagedCluster) bool {
+	if cluster == nil {
+		return false
+	}
+
+	if !isManagedClusterAvailable(cluster) {
+		return false
+	}
+
+	if cluster.Labels == nil {
+		return false
+	}
+
+	if _, found := cluster.Labels[clusterTemplateArtifactsLabel]; !found {
+		return false
+	}
+
+	if _, found := cluster.Labels[clusterIDLabel]; !found {
+		return false
+	}
+
+	return hasManagedClusterClientURL(cluster)
+}
+
+// isManagedClusterAvailable reports whether the O2IMS operator would consider a cluster available. The operator filters
+// out only nil or False ManagedClusterConditionAvailable; Unknown is treated as eligible.
+func isManagedClusterAvailable(cluster *clusterv1.ManagedCluster) bool {
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+
+	return condition != nil && condition.Status != metav1.ConditionFalse
+}
+
+// hasManagedClusterClientURL reports whether the ManagedCluster has a client URL. This corresponds to the API endpoint
+// of the managed cluster.
+func hasManagedClusterClientURL(cluster *clusterv1.ManagedCluster) bool {
+	for _, config := range cluster.Spec.ManagedClusterClientConfigs {
+		if config.URL != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // isLocalManagedCluster reports whether cluster is the ACM hub cluster (local-cluster=true).

--- a/pkg/ocm/managedclusterlist_test.go
+++ b/pkg/ocm/managedclusterlist_test.go
@@ -68,7 +68,7 @@ func TestListManagedClusters(t *testing.T) {
 	}
 }
 
-func TestListORANEligibleManagedClusters(t *testing.T) {
+func TestListNodeClusterEligibleManagedClusters(t *testing.T) {
 	clusterID := uuid.New().String()
 	templateID := uuid.New().String()
 
@@ -78,9 +78,9 @@ func TestListORANEligibleManagedClusters(t *testing.T) {
 		expectedNames []string
 	}{
 		{
-			name: "returns only ORAN-eligible clusters",
+			name: "returns only node-cluster-eligible clusters",
 			clusters: []*clusterv1.ManagedCluster{
-				buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
+				buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
 				buildDummyManagedCluster("not-yet-available"),
 			},
 			expectedNames: []string{testSpokeClusterName},
@@ -88,7 +88,7 @@ func TestListORANEligibleManagedClusters(t *testing.T) {
 		{
 			name: "includes hub cluster without template id label",
 			clusters: []*clusterv1.ManagedCluster{
-				buildORANEligibleHubManagedCluster(testHubClusterName, clusterID),
+				buildNodeClusterEligibleHubManagedCluster(clusterID),
 			},
 			expectedNames: []string{testHubClusterName},
 		},
@@ -106,7 +106,7 @@ func TestListORANEligibleManagedClusters(t *testing.T) {
 				SchemeAttachers: clusterTestSchemes,
 			})
 
-			builders, err := ListORANEligibleManagedClusters(testSettings)
+			builders, err := ListNodeClusterEligibleManagedClusters(testSettings)
 			assert.NoError(t, err)
 			assert.Len(t, builders, len(testCase.expectedNames))
 
@@ -120,36 +120,99 @@ func TestListORANEligibleManagedClusters(t *testing.T) {
 	}
 }
 
-func TestIsORANEligibleManagedCluster(t *testing.T) {
+func TestListDeploymentManagerEligibleManagedClusters(t *testing.T) {
 	clusterID := uuid.New().String()
 	templateID := uuid.New().String()
 
 	testCases := []struct {
-		name    string
-		cluster *clusterv1.ManagedCluster
+		name          string
+		clusters      []*clusterv1.ManagedCluster
+		expectedNames []string
 	}{
 		{
-			name:    "eligible spoke cluster",
-			cluster: buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
+			name: "returns only deployment-manager-eligible clusters",
+			clusters: []*clusterv1.ManagedCluster{
+				buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
+				buildDummyManagedCluster("not-yet-available"),
+				func() *clusterv1.ManagedCluster {
+					cluster := buildDeploymentManagerEligibleHubManagedCluster(clusterID, templateID)
+					delete(cluster.Labels, clusterTemplateArtifactsLabel)
+
+					return cluster
+				}(),
+			},
+			expectedNames: []string{testSpokeClusterName},
 		},
 		{
-			name:    "eligible hub cluster",
-			cluster: buildORANEligibleHubManagedCluster(testHubClusterName, clusterID),
+			name: "includes cluster with non-uuid cluster id",
+			clusters: []*clusterv1.ManagedCluster{
+				buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, "not-a-uuid", templateID),
+			},
+			expectedNames: []string{testSpokeClusterName},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			runtimeObjects := make([]runtime.Object, 0, len(testCase.clusters))
+			for _, cluster := range testCase.clusters {
+				runtimeObjects = append(runtimeObjects, cluster)
+			}
+
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: clusterTestSchemes,
+			})
+
+			builders, err := ListDeploymentManagerEligibleManagedClusters(testSettings)
+			assert.NoError(t, err)
+			assert.Len(t, builders, len(testCase.expectedNames))
+
+			names := make([]string, 0, len(builders))
+			for _, builder := range builders {
+				names = append(names, builder.Definition.Name)
+			}
+
+			assert.ElementsMatch(t, testCase.expectedNames, names)
+		})
+	}
+}
+
+//nolint:funlen // table-driven test with multiple eligibility scenarios.
+func TestIsNodeClusterEligibleManagedCluster(t *testing.T) {
+	clusterID := uuid.New().String()
+	templateID := uuid.New().String()
+
+	testCases := []struct {
+		name     string
+		cluster  *clusterv1.ManagedCluster
+		eligible bool
+	}{
+		{
+			name:     "eligible spoke cluster",
+			cluster:  buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
+			eligible: true,
+		},
+		{
+			name:     "eligible hub cluster",
+			cluster:  buildNodeClusterEligibleHubManagedCluster(clusterID),
+			eligible: true,
 		},
 		{
 			name: "non-openshift vendor without openshift version",
 			cluster: func() *clusterv1.ManagedCluster {
-				cluster := buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
 				cluster.Labels[clusterVendorLabel] = "OtherVendor"
 				delete(cluster.Labels, openshiftVersionLabel)
 
 				return cluster
 			}(),
+			eligible: true,
 		},
 		{
 			name: "available condition unknown",
 			cluster: func() *clusterv1.ManagedCluster {
-				cluster := buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
 				cluster.Status.Conditions = []metav1.Condition{{
 					Type:   clusterv1.ManagedClusterConditionAvailable,
 					Status: metav1.ConditionUnknown,
@@ -157,18 +220,219 @@ func TestIsORANEligibleManagedCluster(t *testing.T) {
 
 				return cluster
 			}(),
+			eligible: true,
+		},
+		{
+			name:     "invalid cluster id",
+			cluster:  buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, "not-a-uuid", templateID),
+			eligible: false,
+		},
+		{
+			name: "missing cluster id label",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				delete(cluster.Labels, clusterIDLabel)
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "available condition false",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Status.Conditions = []metav1.Condition{{
+					Type:   clusterv1.ManagedClusterConditionAvailable,
+					Status: metav1.ConditionFalse,
+				}}
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "spoke without template id",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				delete(cluster.Labels, clusterTemplateArtifactsLabel)
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "missing available condition",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Status.Conditions = nil
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "missing vendor label",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				delete(cluster.Labels, clusterVendorLabel)
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "openshift vendor without openshift version",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				delete(cluster.Labels, openshiftVersionLabel)
+
+				return cluster
+			}(),
+			eligible: false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			assert.True(t, IsORANEligibleManagedCluster(testCase.cluster))
+			assert.Equal(t, testCase.eligible, IsNodeClusterEligibleManagedCluster(testCase.cluster))
 		})
 	}
 }
 
-// buildORANEligibleSpokeManagedCluster returns a spoke ManagedCluster that passes all ORAN eligibility checks.
-func buildORANEligibleSpokeManagedCluster(name, clusterID, templateID string) *clusterv1.ManagedCluster {
+//nolint:funlen // table-driven test with multiple eligibility scenarios.
+func TestIsDeploymentManagerEligibleManagedCluster(t *testing.T) {
+	clusterID := uuid.New().String()
+	templateID := uuid.New().String()
+
+	testCases := []struct {
+		name     string
+		cluster  *clusterv1.ManagedCluster
+		eligible bool
+	}{
+		{
+			name:     "eligible spoke cluster",
+			cluster:  buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
+			eligible: true,
+		},
+		{
+			name:     "eligible hub cluster",
+			cluster:  buildDeploymentManagerEligibleHubManagedCluster(clusterID, templateID),
+			eligible: true,
+		},
+		{
+			name:     "non-uuid cluster id",
+			cluster:  buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, "not-a-uuid", templateID),
+			eligible: true,
+		},
+		{
+			name: "cluster without vendor label",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				delete(cluster.Labels, clusterVendorLabel)
+				delete(cluster.Labels, openshiftVersionLabel)
+
+				return cluster
+			}(),
+			eligible: true,
+		},
+		{
+			name: "available condition unknown",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Status.Conditions = []metav1.Condition{{
+					Type:   clusterv1.ManagedClusterConditionAvailable,
+					Status: metav1.ConditionUnknown,
+				}}
+
+				return cluster
+			}(),
+			eligible: true,
+		},
+		{
+			name: "hub cluster without template id",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleHubManagedCluster(clusterID, templateID)
+				delete(cluster.Labels, clusterTemplateArtifactsLabel)
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "spoke without template id",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				delete(cluster.Labels, clusterTemplateArtifactsLabel)
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "missing client url",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Spec.ManagedClusterClientConfigs = nil
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "empty client url",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Spec.ManagedClusterClientConfigs = []clusterv1.ClientConfig{{URL: ""}}
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "missing cluster id label",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				delete(cluster.Labels, clusterIDLabel)
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "available condition false",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Status.Conditions = []metav1.Condition{{
+					Type:   clusterv1.ManagedClusterConditionAvailable,
+					Status: metav1.ConditionFalse,
+				}}
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "missing available condition",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Status.Conditions = nil
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.eligible, IsDeploymentManagerEligibleManagedCluster(testCase.cluster))
+		})
+	}
+}
+
+// buildNodeClusterEligibleSpokeManagedCluster returns a spoke ManagedCluster that passes all NodeCluster eligibility
+// checks.
+func buildNodeClusterEligibleSpokeManagedCluster(name, clusterID, templateID string) *clusterv1.ManagedCluster {
 	cluster := buildDummyManagedCluster(name)
 	cluster.Labels = map[string]string{
 		clusterVendorLabel:            openshiftVendor,
@@ -184,11 +448,32 @@ func buildORANEligibleSpokeManagedCluster(name, clusterID, templateID string) *c
 	return cluster
 }
 
-// buildORANEligibleHubManagedCluster returns a hub ManagedCluster that passes all ORAN eligibility checks.
-func buildORANEligibleHubManagedCluster(name, clusterID string) *clusterv1.ManagedCluster {
-	cluster := buildORANEligibleSpokeManagedCluster(name, clusterID, uuid.New().String())
+// buildNodeClusterEligibleHubManagedCluster returns a hub ManagedCluster that passes all NodeCluster eligibility
+// checks.
+func buildNodeClusterEligibleHubManagedCluster(clusterID string) *clusterv1.ManagedCluster {
+	cluster := buildNodeClusterEligibleSpokeManagedCluster(testHubClusterName, clusterID, uuid.New().String())
 	cluster.Labels[localClusterLabel] = "true"
 	delete(cluster.Labels, clusterTemplateArtifactsLabel)
+
+	return cluster
+}
+
+// buildDeploymentManagerEligibleSpokeManagedCluster returns a spoke ManagedCluster that passes all DeploymentManager
+// eligibility checks.
+func buildDeploymentManagerEligibleSpokeManagedCluster(name, clusterID, templateID string) *clusterv1.ManagedCluster {
+	cluster := buildNodeClusterEligibleSpokeManagedCluster(name, clusterID, templateID)
+	cluster.Spec.ManagedClusterClientConfigs = []clusterv1.ClientConfig{{
+		URL: "https://api.example.com:6443",
+	}}
+
+	return cluster
+}
+
+// buildDeploymentManagerEligibleHubManagedCluster returns a hub ManagedCluster that passes all DeploymentManager
+// eligibility checks.
+func buildDeploymentManagerEligibleHubManagedCluster(clusterID, templateID string) *clusterv1.ManagedCluster {
+	cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testHubClusterName, clusterID, templateID)
+	cluster.Labels[localClusterLabel] = "true"
 
 	return cluster
 }

--- a/pkg/ocm/managedclusterlist_test.go
+++ b/pkg/ocm/managedclusterlist_test.go
@@ -255,6 +255,16 @@ func TestIsNodeClusterEligibleManagedCluster(t *testing.T) {
 			eligible: false,
 		},
 		{
+			name: "nil labels",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Labels = nil
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
 			name: "available condition false",
 			cluster: func() *clusterv1.ManagedCluster {
 				cluster := buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
@@ -415,6 +425,16 @@ func TestIsDeploymentManagerEligibleManagedCluster(t *testing.T) {
 			cluster: func() *clusterv1.ManagedCluster {
 				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
 				delete(cluster.Labels, clusterIDLabel)
+
+				return cluster
+			}(),
+			eligible: false,
+		},
+		{
+			name: "nil labels",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Labels = nil
 
 				return cluster
 			}(),

--- a/pkg/ocm/managedclusterlist_test.go
+++ b/pkg/ocm/managedclusterlist_test.go
@@ -118,6 +118,12 @@ func TestListNodeClusterEligibleManagedClusters(t *testing.T) {
 			assert.ElementsMatch(t, testCase.expectedNames, names)
 		})
 	}
+
+	t.Run("returns error when apiClient is nil", func(t *testing.T) {
+		builders, err := ListNodeClusterEligibleManagedClusters(nil)
+		assert.EqualError(t, err, "failed to list managedClusters, 'apiClient' parameter is nil")
+		assert.Nil(t, builders)
+	})
 }
 
 func TestListDeploymentManagerEligibleManagedClusters(t *testing.T) {
@@ -176,6 +182,12 @@ func TestListDeploymentManagerEligibleManagedClusters(t *testing.T) {
 			assert.ElementsMatch(t, testCase.expectedNames, names)
 		})
 	}
+
+	t.Run("returns error when apiClient is nil", func(t *testing.T) {
+		builders, err := ListDeploymentManagerEligibleManagedClusters(nil)
+		assert.EqualError(t, err, "failed to list managedClusters, 'apiClient' parameter is nil")
+		assert.Nil(t, builders)
+	})
 }
 
 //nolint:funlen // table-driven test with multiple eligibility scenarios.
@@ -188,6 +200,11 @@ func TestIsNodeClusterEligibleManagedCluster(t *testing.T) {
 		cluster  *clusterv1.ManagedCluster
 		eligible bool
 	}{
+		{
+			name:     "nil cluster",
+			cluster:  nil,
+			eligible: false,
+		},
 		{
 			name:     "eligible spoke cluster",
 			cluster:  buildNodeClusterEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
@@ -309,6 +326,11 @@ func TestIsDeploymentManagerEligibleManagedCluster(t *testing.T) {
 		cluster  *clusterv1.ManagedCluster
 		eligible bool
 	}{
+		{
+			name:     "nil cluster",
+			cluster:  nil,
+			eligible: false,
+		},
 		{
 			name:     "eligible spoke cluster",
 			cluster:  buildDeploymentManagerEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),


### PR DESCRIPTION
This commit splits the O-RAN eligibility function for listing into two separate functions for the ManagedCluster. This is since the criteria are slightly different for the inventory API (DeploymentManager) versus for the clusters API (NodeCluster).

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate eligibility handling for Node Clusters and Deployment Managers.
  * Node Cluster discovery now evaluates availability, provisioning status, local-cluster exceptions, and conversion requirements.
  * Deployment Manager discovery now validates availability, provisioning status, cluster identity, and client connectivity.

* **Bug Fixes**
  * Improved filtering to exclude clusters missing required configuration or connectivity details.

* **Tests**
  * Expanded coverage for Node Cluster and Deployment Manager discovery and eligibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->