### PR TITLE
bmh: add O-RAN eligibility functions for BMH

### DIFF
--- a/pkg/bmh/list.go
+++ b/pkg/bmh/list.go
@@ -3,6 +3,7 @@ package bmh
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,6 +18,10 @@ import (
 
 const (
 	fiveScds time.Duration = 5 * time.Second
+
+	// O2IMS inventory eligibility labels mirror oran-o2ims hardwaremanager/controller/inventory.go.
+	labelResourcePoolName       = "resources.clcm.openshift.io/resourcePoolName"
+	labelPrefixResourceSelector = "resourceselector.clcm.openshift.io/"
 )
 
 // List returns bareMetalHosts inventory in the given namespace.
@@ -79,6 +84,71 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...goclient.ListOp
 	klog.V(100).Info(logMessage)
 
 	return list(apiClient, passedOptions)
+}
+
+// ListInventoryEligibleBMH lists BareMetalHosts that match the O2IMS hardware inventory collector criteria.
+func ListInventoryEligibleBMH(apiClient *clients.Settings, options ...goclient.ListOptions) ([]*BmhBuilder, error) {
+	bmhList, err := ListInAllNamespaces(apiClient, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	var eligibleBMHs []*BmhBuilder
+
+	for _, baremetalhost := range bmhList {
+		if IsInventoryEligibleBMH(baremetalhost.Definition) {
+			eligibleBMHs = append(eligibleBMHs, baremetalhost)
+		}
+	}
+
+	return eligibleBMHs, nil
+}
+
+// IsInventoryEligibleBMH reports whether a BareMetalHost would be included in the O2IMS hardware inventory.
+func IsInventoryEligibleBMH(bmh *bmhv1alpha1.BareMetalHost) bool {
+	if !isOCloudManagedBMH(bmh) {
+		return false
+	}
+
+	switch bmh.Status.Provisioning.State {
+	case bmhv1alpha1.StateAvailable,
+		bmhv1alpha1.StateProvisioning,
+		bmhv1alpha1.StateProvisioned,
+		bmhv1alpha1.StateExternallyProvisioned,
+		bmhv1alpha1.StatePreparing,
+		bmhv1alpha1.StateDeprovisioning:
+		return true
+	case bmhv1alpha1.StateNone,
+		bmhv1alpha1.StateUnmanaged,
+		bmhv1alpha1.StateRegistering,
+		bmhv1alpha1.StateMatchProfile,
+		bmhv1alpha1.StateReady,
+		bmhv1alpha1.StateInspecting,
+		bmhv1alpha1.StatePoweringOffBeforeDelete,
+		bmhv1alpha1.StateDeleting:
+		return false
+	}
+
+	return false
+}
+
+// isOCloudManagedBMH reports whether a BareMetalHost is managed by O-Cloud Manager based on required labels.
+func isOCloudManagedBMH(bmh *bmhv1alpha1.BareMetalHost) bool {
+	if bmh == nil || bmh.Labels == nil {
+		return false
+	}
+
+	if bmh.Labels[labelResourcePoolName] != "" {
+		return true
+	}
+
+	for label := range bmh.Labels {
+		if strings.HasPrefix(label, labelPrefixResourceSelector) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // WaitForAllBareMetalHostsInGoodOperationalState waits for all baremetalhosts to be in good Operational State

--- a/pkg/bmh/list_test.go
+++ b/pkg/bmh/list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -204,4 +205,164 @@ func TestBareMetalWaitForAllBareMetalHostsInGoodOperationalState(t *testing.T) {
 		assert.Equal(t, testCase.expectedError, err)
 		assert.Equal(t, testCase.expectedStatus, status)
 	}
+}
+
+func TestListInventoryEligibleBMH(t *testing.T) {
+	testCases := []struct {
+		name           string
+		bareMetalHosts []runtime.Object
+		listOptions    []goclient.ListOptions
+		client         bool
+		expectedError  error
+		expectedNames  []string
+	}{
+		{
+			name: "returns only inventory-eligible baremetalhosts",
+			bareMetalHosts: []runtime.Object{
+				buildInventoryEligibleBMH("eligible-bmh", defaultBmHostNsName, bmhv1alpha1.StateProvisioned),
+				buildDummyBmHost(bmhv1alpha1.StateProvisioned, bmhv1alpha1.OperationalStatusOK),
+				buildInventoryEligibleBMH("eligible-available", defaultBmHostNsName, bmhv1alpha1.StateAvailable),
+				buildInventoryEligibleBMH("ineligible-state", defaultBmHostNsName, bmhv1alpha1.StateInspecting),
+			},
+			expectedNames: []string{"eligible-bmh", "eligible-available"},
+			client:        true,
+		},
+		{
+			name: "includes resource selector label without resource pool name",
+			bareMetalHosts: []runtime.Object{
+				buildInventoryEligibleBMHWithLabels("selector-bmh", defaultBmHostNsName, bmhv1alpha1.StateProvisioned, map[string]string{
+					labelPrefixResourceSelector + "zone": "east",
+				}),
+			},
+			expectedNames: []string{"selector-bmh"},
+			client:        true,
+		},
+		{
+			name: "supports list options",
+			bareMetalHosts: []runtime.Object{
+				buildInventoryEligibleBMH("eligible-bmh", defaultBmHostNsName, bmhv1alpha1.StateProvisioned),
+			},
+			listOptions:   []goclient.ListOptions{{LabelSelector: labels.NewSelector()}},
+			expectedNames: []string{"eligible-bmh"},
+			client:        true,
+		},
+		{
+			name:          "rejects multiple list options",
+			listOptions:   []goclient.ListOptions{{LabelSelector: labels.NewSelector()}, {LabelSelector: labels.NewSelector()}},
+			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
+			client:        true,
+		},
+		{
+			name:          "requires api client",
+			expectedError: fmt.Errorf("failed to list bareMetalHosts, 'apiClient' parameter is empty"),
+			client:        false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var testSettings *clients.Settings
+
+			if testCase.client {
+				testSettings = clients.GetTestClients(clients.TestClientParams{
+					K8sMockObjects:  testCase.bareMetalHosts,
+					SchemeAttachers: testSchemes,
+				})
+			}
+
+			bmhBuilders, err := ListInventoryEligibleBMH(testSettings, testCase.listOptions...)
+			assert.Equal(t, testCase.expectedError, err)
+
+			if testCase.expectedError != nil {
+				return
+			}
+
+			assert.Len(t, bmhBuilders, len(testCase.expectedNames))
+
+			names := make([]string, 0, len(bmhBuilders))
+			for _, builder := range bmhBuilders {
+				names = append(names, builder.Definition.Name)
+			}
+
+			assert.ElementsMatch(t, testCase.expectedNames, names)
+		})
+	}
+}
+
+func TestIsInventoryEligibleBMH(t *testing.T) {
+	testCases := []struct {
+		name     string
+		bmh      *bmhv1alpha1.BareMetalHost
+		expected bool
+	}{
+		{
+			name:     "nil baremetalhost",
+			bmh:      nil,
+			expected: false,
+		},
+		{
+			name:     "missing labels",
+			bmh:      buildDummyBmHost(bmhv1alpha1.StateProvisioned, bmhv1alpha1.OperationalStatusOK),
+			expected: false,
+		},
+		{
+			name: "resource pool name with eligible state",
+			bmh: buildInventoryEligibleBMHWithLabels("eligible-bmh", defaultBmHostNsName,
+				bmhv1alpha1.StateProvisioned, map[string]string{
+					labelResourcePoolName: "pool123",
+				}),
+			expected: true,
+		},
+		{
+			name: "resource selector label with eligible state",
+			bmh: buildInventoryEligibleBMHWithLabels("selector-bmh", defaultBmHostNsName,
+				bmhv1alpha1.StateAvailable, map[string]string{
+					labelPrefixResourceSelector + "zone": "east",
+				}),
+			expected: true,
+		},
+		{
+			name: "resource pool name with ineligible state",
+			bmh: buildInventoryEligibleBMHWithLabels("ineligible-bmh", defaultBmHostNsName,
+				bmhv1alpha1.StateInspecting, map[string]string{
+					labelResourcePoolName: "pool123",
+				}),
+			expected: false,
+		},
+		{
+			name: "eligible deprovisioning state",
+			bmh: buildInventoryEligibleBMHWithLabels("deprovisioning-bmh", defaultBmHostNsName,
+				bmhv1alpha1.StateDeprovisioning, map[string]string{
+					labelResourcePoolName: "pool123",
+				}),
+			expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, IsInventoryEligibleBMH(testCase.bmh))
+		})
+	}
+}
+
+// buildInventoryEligibleBMH returns a BareMetalHost with the resource pool label required for inventory eligibility.
+func buildInventoryEligibleBMH(name, namespace string, state bmhv1alpha1.ProvisioningState) *bmhv1alpha1.BareMetalHost {
+	return buildInventoryEligibleBMHWithLabels(name, namespace, state, map[string]string{
+		labelResourcePoolName: "pool123",
+	})
+}
+
+// buildInventoryEligibleBMHWithLabels returns a BareMetalHost with the provided inventory eligibility labels.
+func buildInventoryEligibleBMHWithLabels(
+	name, namespace string,
+	state bmhv1alpha1.ProvisioningState,
+	labels map[string]string,
+) *bmhv1alpha1.BareMetalHost {
+	bmh := buildDummyBmHost(state, bmhv1alpha1.OperationalStatusOK)
+	bmh.Name = name
+	bmh.Namespace = namespace
+	bmh.Labels = labels
+
+	return bmh
 }

--- a/pkg/bmh/list_test.go
+++ b/pkg/bmh/list_test.go
@@ -2,6 +2,7 @@ package bmh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -9,9 +10,11 @@ import (
 	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestBareMetalHostList(t *testing.T) {
@@ -207,14 +210,17 @@ func TestBareMetalWaitForAllBareMetalHostsInGoodOperationalState(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestListInventoryEligibleBMH(t *testing.T) {
 	testCases := []struct {
-		name           string
-		bareMetalHosts []runtime.Object
-		listOptions    []goclient.ListOptions
-		client         bool
-		expectedError  error
-		expectedNames  []string
+		name             string
+		bareMetalHosts   []runtime.Object
+		listOptions      []goclient.ListOptions
+		client           bool
+		interceptorFuncs interceptor.Funcs
+		expectedError    error
+		assertError      func(error) bool
+		expectedNames    []string
 	}{
 		{
 			name: "returns only inventory-eligible baremetalhosts",
@@ -257,6 +263,26 @@ func TestListInventoryEligibleBMH(t *testing.T) {
 			expectedError: fmt.Errorf("failed to list bareMetalHosts, 'apiClient' parameter is empty"),
 			client:        false,
 		},
+		{
+			name: "propagates list errors",
+			bareMetalHosts: []runtime.Object{
+				buildInventoryEligibleBMH("eligible-bmh", defaultBmHostNsName, bmhv1alpha1.StateProvisioned),
+			},
+			client: true,
+			interceptorFuncs: interceptor.Funcs{
+				List: func(
+					_ context.Context,
+					_ goclient.WithWatch,
+					_ goclient.ObjectList,
+					_ ...goclient.ListOption,
+				) error {
+					return errors.New("simulated list failure")
+				},
+			},
+			assertError: func(err error) bool {
+				return err != nil && err.Error() == "simulated list failure"
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -265,12 +291,19 @@ func TestListInventoryEligibleBMH(t *testing.T) {
 
 			if testCase.client {
 				testSettings = clients.GetTestClients(clients.TestClientParams{
-					K8sMockObjects:  testCase.bareMetalHosts,
-					SchemeAttachers: testSchemes,
+					K8sMockObjects:   testCase.bareMetalHosts,
+					SchemeAttachers:  testSchemes,
+					InterceptorFuncs: testCase.interceptorFuncs,
 				})
 			}
 
 			bmhBuilders, err := ListInventoryEligibleBMH(testSettings, testCase.listOptions...)
+			if testCase.assertError != nil {
+				require.True(t, testCase.assertError(err), "unexpected error: %v", err)
+
+				return
+			}
+
 			assert.Equal(t, testCase.expectedError, err)
 
 			if testCase.expectedError != nil {
@@ -322,10 +355,10 @@ func TestIsInventoryEligibleBMH(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "resource pool name with ineligible state",
-			bmh: buildInventoryEligibleBMHWithLabels("ineligible-bmh", defaultBmHostNsName,
-				bmhv1alpha1.StateInspecting, map[string]string{
-					labelResourcePoolName: "pool123",
+			name: "empty resource pool name without selector labels",
+			bmh: buildInventoryEligibleBMHWithLabels("empty-pool-bmh", defaultBmHostNsName,
+				bmhv1alpha1.StateProvisioned, map[string]string{
+					labelResourcePoolName: "",
 				}),
 			expected: false,
 		},
@@ -342,6 +375,43 @@ func TestIsInventoryEligibleBMH(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			assert.Equal(t, testCase.expected, IsInventoryEligibleBMH(testCase.bmh))
+		})
+	}
+}
+
+func TestIsInventoryEligibleBMHProvisioningStates(t *testing.T) {
+	rejectedStates := []bmhv1alpha1.ProvisioningState{
+		bmhv1alpha1.StateNone,
+		bmhv1alpha1.StateUnmanaged,
+		bmhv1alpha1.StateRegistering,
+		bmhv1alpha1.StateMatchProfile,
+		bmhv1alpha1.StateReady,
+		bmhv1alpha1.StateInspecting,
+		bmhv1alpha1.StatePoweringOffBeforeDelete,
+		bmhv1alpha1.StateDeleting,
+	}
+
+	for _, state := range rejectedStates {
+		t.Run(fmt.Sprintf("rejects %s provisioning state", state), func(t *testing.T) {
+			bmh := buildInventoryEligibleBMHWithLabels("state-bmh", defaultBmHostNsName, state, map[string]string{
+				labelResourcePoolName: "pool123",
+			})
+			assert.False(t, IsInventoryEligibleBMH(bmh))
+		})
+	}
+
+	eligibleStates := []bmhv1alpha1.ProvisioningState{
+		bmhv1alpha1.StateProvisioning,
+		bmhv1alpha1.StateExternallyProvisioned,
+		bmhv1alpha1.StatePreparing,
+	}
+
+	for _, state := range eligibleStates {
+		t.Run(fmt.Sprintf("accepts %s provisioning state", state), func(t *testing.T) {
+			bmh := buildInventoryEligibleBMHWithLabels("state-bmh", defaultBmHostNsName, state, map[string]string{
+				labelResourcePoolName: "pool123",
+			})
+			assert.True(t, IsInventoryEligibleBMH(bmh))
 		})
 	}
 }


### PR DESCRIPTION
This commit introduces IsInventoryEligibleBMH/ListInventoryEligibleBMH, which work with finding BareMetalHost resources which fit the criteria for inclusion in the O2IMS's inventory API.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying BareMetalHosts eligible for inventory management.
  * Added filtering based on O-Cloud management labels and supported provisioning states.
  * Added support for list options when retrieving eligible hosts.
  * Improved inventory workflows by making eligible hosts easier to discover and manage.

* **Bug Fixes**
  * Improved handling of missing clients, empty entries, and invalid host states during eligibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->