### PR TITLE
Add Neuron DRA builder support and DRA resource helpers

### DIFF
--- a/pkg/neuron/deviceconfig.go
+++ b/pkg/neuron/deviceconfig.go
@@ -32,6 +32,7 @@ type AdditionalOptions func(builder *Builder) (*Builder, error)
 const (
 	errDriverVersionEmpty     = "DeviceConfig 'driverVersion' cannot be empty"
 	errDevicePluginImageEmpty = "DeviceConfig 'devicePluginImage' cannot be empty"
+	errDRADriverImageEmpty    = "DeviceConfig 'draDriverImage' cannot be empty"
 )
 
 // NewBuilder creates a new instance of Builder.
@@ -183,6 +184,206 @@ func NewBuilderWithInClusterBuild(
 
 		return builder
 	}
+
+	return builder
+}
+
+// NewBuilderWithDRA creates a new instance of Builder for DRA mode.
+// In DRA mode, draDriverImage replaces devicePluginImage and custom scheduler.
+func NewBuilderWithDRA(
+	apiClient *clients.Settings,
+	name, namespace string,
+	driversImage, driverVersion, draDriverImage string) *Builder {
+	klog.V(100).Infof(
+		"Initializing new DeviceConfig (DRA mode) with name: %s, namespace: %s",
+		name, namespace)
+
+	if apiClient == nil {
+		klog.V(100).Infof("The apiClient is empty")
+
+		return nil
+	}
+
+	err := apiClient.AttachScheme(neuronv1beta1.AddToScheme)
+	if err != nil {
+		klog.V(100).Infof("Failed to add neuron v1beta1 scheme to client schemes")
+
+		return nil
+	}
+
+	builder := &Builder{
+		apiClient: apiClient,
+		Definition: &neuronv1beta1.DeviceConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: neuronv1beta1.DeviceConfigSpec{
+				DriversImage:   driversImage,
+				DriverVersion:  driverVersion,
+				DRADriverImage: draDriverImage,
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Infof("The name of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+
+		return builder
+	}
+
+	if namespace == "" {
+		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+
+		return builder
+	}
+
+	if driversImage == "" {
+		klog.V(100).Infof("The driversImage of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'driversImage' cannot be empty"
+
+		return builder
+	}
+
+	if driverVersion == "" {
+		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
+
+		builder.errorMsg = errDriverVersionEmpty
+
+		return builder
+	}
+
+	if draDriverImage == "" {
+		klog.V(100).Infof("The draDriverImage of the DeviceConfig is empty")
+
+		builder.errorMsg = errDRADriverImageEmpty
+
+		return builder
+	}
+
+	return builder
+}
+
+// NewBuilderWithInClusterBuildDRA creates a new instance of Builder for DRA mode with
+// in-cluster build. DriversImage is left empty so KMM triggers in-cluster builds.
+func NewBuilderWithInClusterBuildDRA(
+	apiClient *clients.Settings,
+	name, namespace string,
+	driverVersion, draDriverImage string) *Builder {
+	klog.V(100).Infof(
+		"Initializing new DeviceConfig (DRA + in-cluster build) with name: %s, namespace: %s",
+		name, namespace)
+
+	if apiClient == nil {
+		klog.V(100).Infof("The apiClient is empty")
+
+		return nil
+	}
+
+	err := apiClient.AttachScheme(neuronv1beta1.AddToScheme)
+	if err != nil {
+		klog.V(100).Infof("Failed to add neuron v1beta1 scheme to client schemes")
+
+		return nil
+	}
+
+	builder := &Builder{
+		apiClient: apiClient,
+		Definition: &neuronv1beta1.DeviceConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: neuronv1beta1.DeviceConfigSpec{
+				DriverVersion:  driverVersion,
+				DRADriverImage: draDriverImage,
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Infof("The name of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+
+		return builder
+	}
+
+	if namespace == "" {
+		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+
+		return builder
+	}
+
+	if driverVersion == "" {
+		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
+
+		builder.errorMsg = errDriverVersionEmpty
+
+		return builder
+	}
+
+	if draDriverImage == "" {
+		klog.V(100).Infof("The draDriverImage of the DeviceConfig is empty")
+
+		builder.errorMsg = errDRADriverImageEmpty
+
+		return builder
+	}
+
+	return builder
+}
+
+// WithDRADriverImage sets the DRA driver image for the DeviceConfig.
+func (builder *Builder) WithDRADriverImage(image string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof(
+		"Setting DeviceConfig %s in namespace %s with draDriverImage: %s",
+		builder.Definition.Name, builder.Definition.Namespace, image)
+
+	if image == "" {
+		klog.V(100).Infof(errDRADriverImageEmpty)
+
+		builder.errorMsg = errDRADriverImageEmpty
+
+		return builder
+	}
+
+	builder.Definition.Spec.DRADriverImage = image
+
+	return builder
+}
+
+// WithDeviceClasses sets custom DeviceClasses on the DeviceConfig.
+func (builder *Builder) WithDeviceClasses(
+	deviceClasses []neuronv1beta1.DeviceClassSpec) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof(
+		"Setting DeviceConfig %s in namespace %s with %d deviceClasses",
+		builder.Definition.Name, builder.Definition.Namespace, len(deviceClasses))
+
+	if len(deviceClasses) == 0 {
+		klog.V(100).Infof("DeviceConfig 'deviceClasses' cannot be empty")
+
+		builder.errorMsg = "DeviceConfig 'deviceClasses' cannot be empty"
+
+		return builder
+	}
+
+	builder.Definition.Spec.DeviceClasses = deviceClasses
 
 	return builder
 }

--- a/pkg/neuron/deviceconfig.go
+++ b/pkg/neuron/deviceconfig.go
@@ -30,6 +30,9 @@ type Builder struct {
 type AdditionalOptions func(builder *Builder) (*Builder, error)
 
 const (
+	errNameEmpty              = "DeviceConfig 'name' cannot be empty"
+	errNamespaceEmpty         = "DeviceConfig 'namespace' cannot be empty"
+	errDriversImageEmpty      = "DeviceConfig 'driversImage' cannot be empty"
 	errDriverVersionEmpty     = "DeviceConfig 'driverVersion' cannot be empty"
 	errDevicePluginImageEmpty = "DeviceConfig 'devicePluginImage' cannot be empty"
 	errDRADriverImageEmpty    = "DeviceConfig 'draDriverImage' cannot be empty"
@@ -75,7 +78,7 @@ func NewBuilder(
 	if name == "" {
 		klog.V(100).Infof("The name of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+		builder.errorMsg = errNameEmpty
 
 		return builder
 	}
@@ -83,7 +86,7 @@ func NewBuilder(
 	if namespace == "" {
 		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+		builder.errorMsg = errNamespaceEmpty
 
 		return builder
 	}
@@ -91,7 +94,7 @@ func NewBuilder(
 	if driversImage == "" {
 		klog.V(100).Infof("The driversImage of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'driversImage' cannot be empty"
+		builder.errorMsg = errDriversImageEmpty
 
 		return builder
 	}
@@ -156,7 +159,7 @@ func NewBuilderWithInClusterBuild(
 	if name == "" {
 		klog.V(100).Infof("The name of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+		builder.errorMsg = errNameEmpty
 
 		return builder
 	}
@@ -164,7 +167,7 @@ func NewBuilderWithInClusterBuild(
 	if namespace == "" {
 		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+		builder.errorMsg = errNamespaceEmpty
 
 		return builder
 	}
@@ -229,7 +232,7 @@ func NewBuilderWithDRA(
 	if name == "" {
 		klog.V(100).Infof("The name of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+		builder.errorMsg = errNameEmpty
 
 		return builder
 	}
@@ -237,7 +240,7 @@ func NewBuilderWithDRA(
 	if namespace == "" {
 		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+		builder.errorMsg = errNamespaceEmpty
 
 		return builder
 	}
@@ -245,7 +248,7 @@ func NewBuilderWithDRA(
 	if driversImage == "" {
 		klog.V(100).Infof("The driversImage of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'driversImage' cannot be empty"
+		builder.errorMsg = errDriversImageEmpty
 
 		return builder
 	}
@@ -309,7 +312,7 @@ func NewBuilderWithInClusterBuildDRA(
 	if name == "" {
 		klog.V(100).Infof("The name of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+		builder.errorMsg = errNameEmpty
 
 		return builder
 	}
@@ -317,7 +320,7 @@ func NewBuilderWithInClusterBuildDRA(
 	if namespace == "" {
 		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+		builder.errorMsg = errNamespaceEmpty
 
 		return builder
 	}

--- a/pkg/neuron/deviceconfig.go
+++ b/pkg/neuron/deviceconfig.go
@@ -36,6 +36,7 @@ const (
 	errDriverVersionEmpty     = "DeviceConfig 'driverVersion' cannot be empty"
 	errDevicePluginImageEmpty = "DeviceConfig 'devicePluginImage' cannot be empty"
 	errDRADriverImageEmpty    = "DeviceConfig 'draDriverImage' cannot be empty"
+	errDeviceClassesEmpty     = "DeviceConfig 'deviceClasses' cannot be empty"
 )
 
 // NewBuilder creates a new instance of Builder.
@@ -379,9 +380,9 @@ func (builder *Builder) WithDeviceClasses(
 		builder.Definition.Name, builder.Definition.Namespace, len(deviceClasses))
 
 	if len(deviceClasses) == 0 {
-		klog.V(100).Infof("DeviceConfig 'deviceClasses' cannot be empty")
+		klog.V(100).Infof(errDeviceClassesEmpty)
 
-		builder.errorMsg = "DeviceConfig 'deviceClasses' cannot be empty"
+		builder.errorMsg = errDeviceClassesEmpty
 
 		return builder
 	}

--- a/pkg/neuron/deviceconfig_test.go
+++ b/pkg/neuron/deviceconfig_test.go
@@ -549,12 +549,12 @@ func TestDeviceConfigWithDeviceClasses(t *testing.T) {
 		{
 			name:          "empty device classes",
 			deviceClasses: []v1beta1.DeviceClassSpec{},
-			expectedError: "DeviceConfig 'deviceClasses' cannot be empty",
+			expectedError: errDeviceClassesEmpty,
 		},
 		{
 			name:          "nil device classes",
 			deviceClasses: nil,
-			expectedError: "DeviceConfig 'deviceClasses' cannot be empty",
+			expectedError: errDeviceClassesEmpty,
 		},
 	}
 

--- a/pkg/neuron/deviceconfig_test.go
+++ b/pkg/neuron/deviceconfig_test.go
@@ -498,6 +498,88 @@ func TestDeviceConfigWithOptions(t *testing.T) {
 	}
 }
 
+func TestDeviceConfigWithDRADriverImage(t *testing.T) {
+	testCases := []struct {
+		draDriverImage string
+		expectedError  string
+	}{
+		{
+			draDriverImage: "public.ecr.aws/neuron/neuron-dra-driver:1.0.0",
+			expectedError:  "",
+		},
+		{
+			draDriverImage: "",
+			expectedError:  errDRADriverImageEmpty,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidDeviceConfigBuilder(buildTestClientWithDummyObject())
+		result := testBuilder.WithDRADriverImage(testCase.draDriverImage)
+
+		if testCase.expectedError == "" {
+			assert.Equal(t, testCase.draDriverImage, result.Definition.Spec.DRADriverImage)
+		} else {
+			assert.Equal(t, testCase.expectedError, result.errorMsg)
+		}
+	}
+}
+
+func TestDeviceConfigWithDRADriverImageInvalidBuilder(t *testing.T) {
+	testBuilder := buildInvalidDeviceConfigBuilder(buildTestClientWithDummyObject())
+	origErr := testBuilder.errorMsg
+
+	result := testBuilder.WithDRADriverImage("public.ecr.aws/neuron/neuron-dra-driver:1.0.0")
+	assert.Equal(t, origErr, result.errorMsg)
+}
+
+func TestDeviceConfigWithDeviceClasses(t *testing.T) {
+	testCases := []struct {
+		name          string
+		deviceClasses []v1beta1.DeviceClassSpec
+		expectedError string
+	}{
+		{
+			name: "valid device classes",
+			deviceClasses: []v1beta1.DeviceClassSpec{
+				{Name: "neuron-device"},
+			},
+			expectedError: "",
+		},
+		{
+			name:          "empty device classes",
+			deviceClasses: []v1beta1.DeviceClassSpec{},
+			expectedError: "DeviceConfig 'deviceClasses' cannot be empty",
+		},
+		{
+			name:          "nil device classes",
+			deviceClasses: nil,
+			expectedError: "DeviceConfig 'deviceClasses' cannot be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testBuilder := buildValidDeviceConfigBuilder(buildTestClientWithDummyObject())
+			result := testBuilder.WithDeviceClasses(testCase.deviceClasses)
+
+			if testCase.expectedError == "" {
+				assert.Equal(t, testCase.deviceClasses, result.Definition.Spec.DeviceClasses)
+			} else {
+				assert.Equal(t, testCase.expectedError, result.errorMsg)
+			}
+		})
+	}
+}
+
+func TestDeviceConfigWithDeviceClassesInvalidBuilder(t *testing.T) {
+	testBuilder := buildInvalidDeviceConfigBuilder(buildTestClientWithDummyObject())
+	origErr := testBuilder.errorMsg
+
+	result := testBuilder.WithDeviceClasses([]v1beta1.DeviceClassSpec{{Name: "test"}})
+	assert.Equal(t, origErr, result.errorMsg)
+}
+
 // buildDummyDeviceConfig returns a DeviceConfig with the provided name and namespace.
 func buildDummyDeviceConfig(name, namespace string) *v1beta1.DeviceConfig {
 	return &v1beta1.DeviceConfig{

--- a/pkg/resource/resourceclaim.go
+++ b/pkg/resource/resourceclaim.go
@@ -1,0 +1,85 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/klog/v2"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListResourceClaims returns ResourceClaim objects matching the given options.
+func ListResourceClaims(
+	apiClient *clients.Settings,
+	namespace string,
+	options ...goclient.ListOption) ([]resourcev1.ResourceClaim, error) {
+	klog.V(100).Infof("Listing ResourceClaims in namespace %s", namespace)
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient is empty")
+
+		return nil, fmt.Errorf("resourceClaim 'apiClient' cannot be nil")
+	}
+
+	if namespace == "" {
+		klog.V(100).Info("The namespace is empty")
+
+		return nil, fmt.Errorf("resourceClaim 'namespace' cannot be empty")
+	}
+
+	err := apiClient.AttachScheme(resourcev1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add resource v1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	claimList := &resourcev1.ResourceClaimList{}
+
+	allOptions := append([]goclient.ListOption{goclient.InNamespace(namespace)}, options...)
+
+	err = apiClient.List(logging.DiscardContext(), claimList, allOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return claimList.Items, nil
+}
+
+// GetResourceClaim fetches a single ResourceClaim by name and namespace.
+func GetResourceClaim(
+	apiClient *clients.Settings,
+	name, namespace string) (*resourcev1.ResourceClaim, error) {
+	klog.V(100).Infof("Getting ResourceClaim %s in namespace %s", name, namespace)
+
+	if apiClient == nil {
+		return nil, fmt.Errorf("resourceClaim 'apiClient' cannot be nil")
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("resourceClaim 'name' cannot be empty")
+	}
+
+	if namespace == "" {
+		return nil, fmt.Errorf("resourceClaim 'namespace' cannot be empty")
+	}
+
+	err := apiClient.AttachScheme(resourcev1.AddToScheme)
+	if err != nil {
+		return nil, err
+	}
+
+	claim := &resourcev1.ResourceClaim{}
+
+	err = apiClient.Get(logging.DiscardContext(), goclient.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}, claim)
+	if err != nil {
+		return nil, err
+	}
+
+	return claim, nil
+}

--- a/pkg/resource/resourceclaim.go
+++ b/pkg/resource/resourceclaim.go
@@ -38,7 +38,7 @@ func ListResourceClaims(
 
 	claimList := &resourcev1.ResourceClaimList{}
 
-	allOptions := append([]goclient.ListOption{goclient.InNamespace(namespace)}, options...)
+	allOptions := append(append([]goclient.ListOption{}, options...), goclient.InNamespace(namespace))
 
 	err = apiClient.List(logging.DiscardContext(), claimList, allOptions...)
 	if err != nil {

--- a/pkg/resource/resourceclaim.go
+++ b/pkg/resource/resourceclaim.go
@@ -1,85 +1,63 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ListResourceClaims returns ResourceClaim objects matching the given options.
+// ResourceClaimBuilder provides a struct for the ResourceClaim resource containing a connection
+// to the cluster and the ResourceClaim definitions.
+type ResourceClaimBuilder struct {
+	common.EmbeddableBuilder[resourcev1.ResourceClaim, *resourcev1.ResourceClaim]
+	common.EmbeddableDeleter[resourcev1.ResourceClaim, *resourcev1.ResourceClaim]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *ResourceClaimBuilder) AttachMixins() {
+	builder.EmbeddableDeleter.SetBase(builder)
+}
+
+// GetGVK returns the ResourceClaim GVK for this builder.
+func (builder *ResourceClaimBuilder) GetGVK() schema.GroupVersionKind {
+	return resourcev1.SchemeGroupVersion.WithKind("ResourceClaim")
+}
+
+// NewResourceClaimBuilder creates a new instance of ResourceClaimBuilder.
+func NewResourceClaimBuilder(
+	apiClient *clients.Settings, name, namespace string) *ResourceClaimBuilder {
+	return common.NewNamespacedBuilder[resourcev1.ResourceClaim, ResourceClaimBuilder](
+		apiClient, resourcev1.AddToScheme, name, namespace)
+}
+
+// PullResourceClaim fetches an existing ResourceClaim from the cluster by name and namespace.
+func PullResourceClaim(
+	apiClient *clients.Settings, name, namespace string) (*ResourceClaimBuilder, error) {
+	return common.PullNamespacedBuilder[resourcev1.ResourceClaim, ResourceClaimBuilder](
+		context.TODO(), apiClient, resourcev1.AddToScheme, name, namespace)
+}
+
+// ListResourceClaims returns ResourceClaim builders matching the given options in the specified namespace.
 func ListResourceClaims(
 	apiClient *clients.Settings,
 	namespace string,
-	options ...goclient.ListOption) ([]resourcev1.ResourceClaim, error) {
+	options ...runtimeclient.ListOption) ([]*ResourceClaimBuilder, error) {
 	klog.V(100).Infof("Listing ResourceClaims in namespace %s", namespace)
 
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("resourceClaim 'apiClient' cannot be nil")
-	}
-
-	if namespace == "" {
-		klog.V(100).Info("The namespace is empty")
-
-		return nil, fmt.Errorf("resourceClaim 'namespace' cannot be empty")
-	}
-
-	err := apiClient.AttachScheme(resourcev1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add resource v1 scheme to client schemes")
-
-		return nil, err
-	}
-
-	claimList := &resourcev1.ResourceClaimList{}
-
-	allOptions := append(append([]goclient.ListOption{}, options...), goclient.InNamespace(namespace))
-
-	err = apiClient.List(logging.DiscardContext(), claimList, allOptions...)
-	if err != nil {
-		return nil, err
-	}
-
-	return claimList.Items, nil
-}
-
-// GetResourceClaim fetches a single ResourceClaim by name and namespace.
-func GetResourceClaim(
-	apiClient *clients.Settings,
-	name, namespace string) (*resourcev1.ResourceClaim, error) {
-	klog.V(100).Infof("Getting ResourceClaim %s in namespace %s", name, namespace)
-
-	if apiClient == nil {
-		return nil, fmt.Errorf("resourceClaim 'apiClient' cannot be nil")
-	}
-
-	if name == "" {
-		return nil, fmt.Errorf("resourceClaim 'name' cannot be empty")
-	}
-
 	if namespace == "" {
 		return nil, fmt.Errorf("resourceClaim 'namespace' cannot be empty")
 	}
 
-	err := apiClient.AttachScheme(resourcev1.AddToScheme)
-	if err != nil {
-		return nil, err
-	}
+	allOptions := append(
+		append([]runtimeclient.ListOption{}, options...),
+		runtimeclient.InNamespace(namespace))
 
-	claim := &resourcev1.ResourceClaim{}
-
-	err = apiClient.Get(logging.DiscardContext(), goclient.ObjectKey{
-		Name:      name,
-		Namespace: namespace,
-	}, claim)
-	if err != nil {
-		return nil, err
-	}
-
-	return claim, nil
+	return common.List[resourcev1.ResourceClaim, resourcev1.ResourceClaimList, ResourceClaimBuilder](
+		context.TODO(), apiClient, resourcev1.AddToScheme, allOptions...)
 }

--- a/pkg/resource/resourceclaim.go
+++ b/pkg/resource/resourceclaim.go
@@ -21,7 +21,7 @@ type ResourceClaimBuilder struct {
 
 // AttachMixins wires the embedded CRUD mixins to this builder instance.
 func (builder *ResourceClaimBuilder) AttachMixins() {
-	builder.EmbeddableDeleter.SetBase(builder)
+	builder.SetBase(builder)
 }
 
 // GetGVK returns the ResourceClaim GVK for this builder.

--- a/pkg/resource/resourceclaim.go
+++ b/pkg/resource/resourceclaim.go
@@ -2,10 +2,11 @@ package resource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	commonkey "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/key"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
@@ -51,7 +52,10 @@ func ListResourceClaims(
 	klog.V(100).Infof("Listing ResourceClaims in namespace %s", namespace)
 
 	if namespace == "" {
-		return nil, fmt.Errorf("resourceClaim 'namespace' cannot be empty")
+		klog.V(100).Info("ResourceClaim 'namespace' parameter can not be empty")
+
+		return nil, commonerrors.NewBuilderFieldEmpty(
+			commonkey.NewResourceKey("ResourceClaim", "", ""), commonerrors.BuilderFieldNamespace)
 	}
 
 	allOptions := append(

--- a/pkg/resource/resourceclaim_test.go
+++ b/pkg/resource/resourceclaim_test.go
@@ -1,0 +1,178 @@
+package resource
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestListResourceClaims(t *testing.T) {
+	testCases := []struct {
+		addToRuntimeObjects bool
+		namespace           string
+		expectedCount       int
+		client              bool
+		expectedError       error
+	}{
+		{
+			addToRuntimeObjects: true,
+			namespace:           "test-ns",
+			expectedCount:       1,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			addToRuntimeObjects: false,
+			namespace:           "test-ns",
+			expectedCount:       0,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			addToRuntimeObjects: true,
+			namespace:           "test-ns",
+			expectedCount:       0,
+			client:              false,
+			expectedError:       fmt.Errorf("resourceClaim 'apiClient' cannot be nil"),
+		},
+		{
+			addToRuntimeObjects: false,
+			namespace:           "",
+			expectedCount:       0,
+			client:              true,
+			expectedError:       fmt.Errorf("resourceClaim 'namespace' cannot be empty"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects,
+				generateResourceClaim("test-claim", "test-ns"))
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: testResourceSchemes,
+			})
+		}
+
+		claims, err := ListResourceClaims(testSettings, testCase.namespace)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Len(t, claims, testCase.expectedCount)
+		}
+	}
+}
+
+func TestListResourceClaimsNamespaceOverride(t *testing.T) {
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: []runtime.Object{
+			generateResourceClaim("test-claim", "correct-ns"),
+		},
+		SchemeAttachers: testResourceSchemes,
+	})
+
+	claims, err := ListResourceClaims(testSettings, "correct-ns",
+		goclient.InNamespace("wrong-ns"))
+	assert.Nil(t, err)
+	assert.Len(t, claims, 1)
+	assert.Equal(t, "test-claim", claims[0].Name)
+}
+
+func TestGetResourceClaim(t *testing.T) {
+	testCases := []struct {
+		name                string
+		namespace           string
+		addToRuntimeObjects bool
+		client              bool
+		expectedError       error
+	}{
+		{
+			name:                "test-claim",
+			namespace:           "test-ns",
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			name:                "test-claim",
+			namespace:           "test-ns",
+			addToRuntimeObjects: false,
+			client:              false,
+			expectedError:       fmt.Errorf("resourceClaim 'apiClient' cannot be nil"),
+		},
+		{
+			name:                "",
+			namespace:           "test-ns",
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedError:       fmt.Errorf("resourceClaim 'name' cannot be empty"),
+		},
+		{
+			name:                "test-claim",
+			namespace:           "",
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedError:       fmt.Errorf("resourceClaim 'namespace' cannot be empty"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects,
+				generateResourceClaim(testCase.name, testCase.namespace))
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: testResourceSchemes,
+			})
+		}
+
+		claim, err := GetResourceClaim(testSettings, testCase.name, testCase.namespace)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.NotNil(t, claim)
+			assert.Equal(t, testCase.name, claim.Name)
+		}
+	}
+}
+
+func TestGetResourceClaimNotFound(t *testing.T) {
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		SchemeAttachers: testResourceSchemes,
+	})
+
+	claim, err := GetResourceClaim(testSettings, "nonexistent", "test-ns")
+	assert.NotNil(t, err)
+	assert.Nil(t, claim)
+}
+
+func generateResourceClaim(name, namespace string) *resourcev1.ResourceClaim {
+	return &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/pkg/resource/resourceclaim_test.go
+++ b/pkg/resource/resourceclaim_test.go
@@ -1,79 +1,104 @@
 package resource
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var resourceClaimGVK = resourcev1.SchemeGroupVersion.WithKind("ResourceClaim")
+
+func TestNewResourceClaimBuilder(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewNamespacedBuilderTestConfig(
+		NewResourceClaimBuilder,
+		resourcev1.AddToScheme,
+		resourceClaimGVK,
+	).ExecuteTests(t)
+}
+
+func TestPullResourceClaim(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewNamespacedPullTestConfig(
+		PullResourceClaim,
+		resourcev1.AddToScheme,
+		resourceClaimGVK,
+	).ExecuteTests(t)
+}
 
 func TestListResourceClaims(t *testing.T) {
 	testCases := []struct {
+		name                string
 		addToRuntimeObjects bool
 		namespace           string
-		expectedCount       int
 		client              bool
-		expectedError       error
+		expectedCount       int
+		expectedError       bool
 	}{
 		{
+			name:                "valid with claims",
 			addToRuntimeObjects: true,
 			namespace:           "test-ns",
+			client:              true,
 			expectedCount:       1,
-			client:              true,
-			expectedError:       nil,
 		},
 		{
+			name:                "valid no claims",
 			addToRuntimeObjects: false,
 			namespace:           "test-ns",
-			expectedCount:       0,
 			client:              true,
-			expectedError:       nil,
+			expectedCount:       0,
 		},
 		{
-			addToRuntimeObjects: true,
-			namespace:           "test-ns",
-			expectedCount:       0,
-			client:              false,
-			expectedError:       fmt.Errorf("resourceClaim 'apiClient' cannot be nil"),
+			name:          "nil apiClient",
+			namespace:     "test-ns",
+			client:        false,
+			expectedError: true,
 		},
 		{
-			addToRuntimeObjects: false,
-			namespace:           "",
-			expectedCount:       0,
-			client:              true,
-			expectedError:       fmt.Errorf("resourceClaim 'namespace' cannot be empty"),
+			name:          "empty namespace",
+			namespace:     "",
+			client:        true,
+			expectedError: true,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
+		t.Run(testCase.name, func(t *testing.T) {
+			var (
+				runtimeObjects []runtime.Object
+				testSettings   *clients.Settings
+			)
 
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects,
-				generateResourceClaim("test-claim", "test-ns"))
-		}
+			if testCase.addToRuntimeObjects {
+				runtimeObjects = append(runtimeObjects,
+					generateResourceClaim("test-claim", "test-ns"))
+			}
 
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: testResourceSchemes,
-			})
-		}
+			if testCase.client {
+				testSettings = clients.GetTestClients(clients.TestClientParams{
+					K8sMockObjects:  runtimeObjects,
+					SchemeAttachers: testResourceSchemes,
+				})
+			}
 
-		claims, err := ListResourceClaims(testSettings, testCase.namespace)
-		assert.Equal(t, testCase.expectedError, err)
+			builders, err := ListResourceClaims(testSettings, testCase.namespace)
 
-		if testCase.expectedError == nil {
-			assert.Len(t, claims, testCase.expectedCount)
-		}
+			if testCase.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, builders, testCase.expectedCount)
+			}
+		})
 	}
 }
 
@@ -85,87 +110,77 @@ func TestListResourceClaimsNamespaceOverride(t *testing.T) {
 		SchemeAttachers: testResourceSchemes,
 	})
 
-	claims, err := ListResourceClaims(testSettings, "correct-ns",
-		goclient.InNamespace("wrong-ns"))
-	assert.Nil(t, err)
-	assert.Len(t, claims, 1)
-	assert.Equal(t, "test-claim", claims[0].Name)
+	builders, err := ListResourceClaims(testSettings, "correct-ns",
+		runtimeclient.InNamespace("wrong-ns"))
+	assert.NoError(t, err)
+	assert.Len(t, builders, 1)
+	assert.Equal(t, "test-claim", builders[0].Object.Name)
 }
 
-func TestGetResourceClaim(t *testing.T) {
+func TestResourceClaimBuilderExists(t *testing.T) {
 	testCases := []struct {
-		name                string
-		namespace           string
-		addToRuntimeObjects bool
-		client              bool
-		expectedError       error
+		name           string
+		addToRuntime   bool
+		expectedStatus bool
 	}{
 		{
-			name:                "test-claim",
-			namespace:           "test-ns",
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedError:       nil,
+			name:           "object exists",
+			addToRuntime:   true,
+			expectedStatus: true,
 		},
 		{
-			name:                "test-claim",
-			namespace:           "test-ns",
-			addToRuntimeObjects: false,
-			client:              false,
-			expectedError:       fmt.Errorf("resourceClaim 'apiClient' cannot be nil"),
-		},
-		{
-			name:                "",
-			namespace:           "test-ns",
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("resourceClaim 'name' cannot be empty"),
-		},
-		{
-			name:                "test-claim",
-			namespace:           "",
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("resourceClaim 'namespace' cannot be empty"),
+			name:           "object does not exist",
+			addToRuntime:   false,
+			expectedStatus: false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
+		t.Run(testCase.name, func(t *testing.T) {
+			var runtimeObjects []runtime.Object
+			if testCase.addToRuntime {
+				runtimeObjects = append(runtimeObjects,
+					generateResourceClaim("test-claim", "test-ns"))
+			}
 
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects,
-				generateResourceClaim(testCase.name, testCase.namespace))
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
+			testSettings := clients.GetTestClients(clients.TestClientParams{
 				K8sMockObjects:  runtimeObjects,
 				SchemeAttachers: testResourceSchemes,
 			})
-		}
 
-		claim, err := GetResourceClaim(testSettings, testCase.name, testCase.namespace)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.NotNil(t, claim)
-			assert.Equal(t, testCase.name, claim.Name)
-		}
+			builder := NewResourceClaimBuilder(testSettings, "test-claim", "test-ns")
+			assert.Equal(t, testCase.expectedStatus, builder.Exists())
+		})
 	}
 }
 
-func TestGetResourceClaimNotFound(t *testing.T) {
+func TestResourceClaimBuilderDelete(t *testing.T) {
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: []runtime.Object{
+			generateResourceClaim("test-claim", "test-ns"),
+		},
+		SchemeAttachers: testResourceSchemes,
+	})
+
+	builder := NewResourceClaimBuilder(testSettings, "test-claim", "test-ns")
+	err := builder.Delete()
+	assert.NoError(t, err)
+	assert.Nil(t, builder.Object)
+}
+
+func TestPullResourceClaimNotFound(t *testing.T) {
 	testSettings := clients.GetTestClients(clients.TestClientParams{
 		SchemeAttachers: testResourceSchemes,
 	})
 
-	claim, err := GetResourceClaim(testSettings, "nonexistent", "test-ns")
-	assert.NotNil(t, err)
-	assert.Nil(t, claim)
+	builder, err := PullResourceClaim(testSettings, "nonexistent", "test-ns")
+	assert.Error(t, err)
+	assert.Nil(t, builder)
+}
+
+func TestResourceClaimBuilderGetGVK(t *testing.T) {
+	builder := &ResourceClaimBuilder{}
+	assert.Equal(t, resourceClaimGVK, builder.GetGVK())
 }
 
 func generateResourceClaim(name, namespace string) *resourcev1.ResourceClaim {

--- a/pkg/resource/resourceclaim_test.go
+++ b/pkg/resource/resourceclaim_test.go
@@ -35,71 +35,31 @@ func TestPullResourceClaim(t *testing.T) {
 }
 
 func TestListResourceClaims(t *testing.T) {
-	testCases := []struct {
-		name                string
-		addToRuntimeObjects bool
-		namespace           string
-		client              bool
-		expectedCount       int
-		expectedError       bool
-	}{
-		{
-			name:                "valid with claims",
-			addToRuntimeObjects: true,
-			namespace:           "test-ns",
-			client:              true,
-			expectedCount:       1,
+	t.Parallel()
+
+	testhelper.NewNamespacedListTestConfig(
+		func(apiClient *clients.Settings, nsname string, _ ...runtimeclient.ListOptions) ([]*ResourceClaimBuilder, error) {
+			return ListResourceClaims(apiClient, nsname)
 		},
-		{
-			name:                "valid no claims",
-			addToRuntimeObjects: false,
-			namespace:           "test-ns",
-			client:              true,
-			expectedCount:       0,
-		},
-		{
-			name:          "nil apiClient",
-			namespace:     "test-ns",
-			client:        false,
-			expectedError: true,
-		},
-		{
-			name:          "empty namespace",
-			namespace:     "",
-			client:        true,
-			expectedError: true,
-		},
-	}
+		resourcev1.AddToScheme,
+		resourceClaimGVK,
+	).ExecuteTests(t)
+}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			var (
-				runtimeObjects []runtime.Object
-				testSettings   *clients.Settings
-			)
+func TestResourceClaimBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-			if testCase.addToRuntimeObjects {
-				runtimeObjects = append(runtimeObjects,
-					generateResourceClaim("test-ns"))
-			}
+	commonTestConfig := testhelper.NewCommonTestConfig[resourcev1.ResourceClaim, ResourceClaimBuilder](
+		resourcev1.AddToScheme,
+		resourceClaimGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
 
-			if testCase.client {
-				testSettings = clients.GetTestClients(clients.TestClientParams{
-					K8sMockObjects:  runtimeObjects,
-					SchemeAttachers: testResourceSchemes,
-				})
-			}
-
-			builders, err := ListResourceClaims(testSettings, testCase.namespace)
-
-			if testCase.expectedError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Len(t, builders, testCase.expectedCount)
-			}
-		})
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleterTestConfig(commonTestConfig)).
+		Run(t)
 }
 
 func TestListResourceClaimsNamespaceOverride(t *testing.T) {
@@ -115,67 +75,6 @@ func TestListResourceClaimsNamespaceOverride(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, builders, 1)
 	assert.Equal(t, "test-claim", builders[0].Object.Name)
-}
-
-func TestResourceClaimBuilderExists(t *testing.T) {
-	testCases := []struct {
-		name           string
-		addToRuntime   bool
-		expectedStatus bool
-	}{
-		{
-			name:           "object exists",
-			addToRuntime:   true,
-			expectedStatus: true,
-		},
-		{
-			name:           "object does not exist",
-			addToRuntime:   false,
-			expectedStatus: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			var runtimeObjects []runtime.Object
-			if testCase.addToRuntime {
-				runtimeObjects = append(runtimeObjects,
-					generateResourceClaim("test-ns"))
-			}
-
-			testSettings := clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: testResourceSchemes,
-			})
-
-			builder := NewResourceClaimBuilder(testSettings, "test-claim", "test-ns")
-			assert.Equal(t, testCase.expectedStatus, builder.Exists())
-		})
-	}
-}
-
-func TestResourceClaimBuilderDelete(t *testing.T) {
-	testSettings := clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: []runtime.Object{
-			generateResourceClaim("test-ns"),
-		},
-		SchemeAttachers: testResourceSchemes,
-	})
-
-	builder := NewResourceClaimBuilder(testSettings, "test-claim", "test-ns")
-	err := builder.Delete()
-	assert.NoError(t, err)
-	assert.Nil(t, builder.Object)
-}
-
-func TestPullResourceClaimNotFound(t *testing.T) {
-	testSettings := clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: testResourceSchemes,
-	})
-
-	builder, err := PullResourceClaim(testSettings, "nonexistent", "test-ns")
-	assert.Error(t, err)
-	assert.Nil(t, builder)
 }
 
 func TestResourceClaimBuilderGetGVK(t *testing.T) {

--- a/pkg/resource/resourceclaim_test.go
+++ b/pkg/resource/resourceclaim_test.go
@@ -80,7 +80,7 @@ func TestListResourceClaims(t *testing.T) {
 
 			if testCase.addToRuntimeObjects {
 				runtimeObjects = append(runtimeObjects,
-					generateResourceClaim("test-claim", "test-ns"))
+					generateResourceClaim("test-ns"))
 			}
 
 			if testCase.client {
@@ -105,7 +105,7 @@ func TestListResourceClaims(t *testing.T) {
 func TestListResourceClaimsNamespaceOverride(t *testing.T) {
 	testSettings := clients.GetTestClients(clients.TestClientParams{
 		K8sMockObjects: []runtime.Object{
-			generateResourceClaim("test-claim", "correct-ns"),
+			generateResourceClaim("correct-ns"),
 		},
 		SchemeAttachers: testResourceSchemes,
 	})
@@ -140,7 +140,7 @@ func TestResourceClaimBuilderExists(t *testing.T) {
 			var runtimeObjects []runtime.Object
 			if testCase.addToRuntime {
 				runtimeObjects = append(runtimeObjects,
-					generateResourceClaim("test-claim", "test-ns"))
+					generateResourceClaim("test-ns"))
 			}
 
 			testSettings := clients.GetTestClients(clients.TestClientParams{
@@ -157,7 +157,7 @@ func TestResourceClaimBuilderExists(t *testing.T) {
 func TestResourceClaimBuilderDelete(t *testing.T) {
 	testSettings := clients.GetTestClients(clients.TestClientParams{
 		K8sMockObjects: []runtime.Object{
-			generateResourceClaim("test-claim", "test-ns"),
+			generateResourceClaim("test-ns"),
 		},
 		SchemeAttachers: testResourceSchemes,
 	})
@@ -183,10 +183,10 @@ func TestResourceClaimBuilderGetGVK(t *testing.T) {
 	assert.Equal(t, resourceClaimGVK, builder.GetGVK())
 }
 
-func generateResourceClaim(name, namespace string) *resourcev1.ResourceClaim {
+func generateResourceClaim(namespace string) *resourcev1.ResourceClaim {
 	return &resourcev1.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      "test-claim",
 			Namespace: namespace,
 		},
 	}

--- a/pkg/resource/resourceclaimtemplate.go
+++ b/pkg/resource/resourceclaimtemplate.go
@@ -1,0 +1,279 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	resourcev1 "k8s.io/api/resource/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ResourceClaimTemplateBuilder provides struct for the ResourceClaimTemplate object
+// containing connection to the cluster and the ResourceClaimTemplate definitions.
+type ResourceClaimTemplateBuilder struct {
+	Definition *resourcev1.ResourceClaimTemplate
+	Object     *resourcev1.ResourceClaimTemplate
+	apiClient  goclient.Client
+	errorMsg   string
+}
+
+// NewResourceClaimTemplateBuilder creates a new instance of ResourceClaimTemplateBuilder.
+func NewResourceClaimTemplateBuilder(
+	apiClient *clients.Settings, name, namespace string) *ResourceClaimTemplateBuilder {
+	klog.V(100).Infof(
+		"Initializing new ResourceClaimTemplateBuilder with name: %s, namespace: %s",
+		name, namespace)
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient is empty")
+
+		return nil
+	}
+
+	err := apiClient.AttachScheme(resourcev1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add resource v1 scheme to client schemes")
+
+		return nil
+	}
+
+	builder := &ResourceClaimTemplateBuilder{
+		apiClient: apiClient.Client,
+		Definition: &resourcev1.ResourceClaimTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Info("The name of the ResourceClaimTemplate is empty")
+
+		builder.errorMsg = "ResourceClaimTemplate 'name' cannot be empty"
+
+		return builder
+	}
+
+	if namespace == "" {
+		klog.V(100).Info("The namespace of the ResourceClaimTemplate is empty")
+
+		builder.errorMsg = "ResourceClaimTemplate 'namespace' cannot be empty"
+
+		return builder
+	}
+
+	return builder
+}
+
+// WithDeviceRequest adds a device request to the ResourceClaimTemplate.
+func (builder *ResourceClaimTemplateBuilder) WithDeviceRequest(
+	requestName, deviceClassName string, count int64) *ResourceClaimTemplateBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	if requestName == "" {
+		builder.errorMsg = "device request 'name' cannot be empty"
+
+		return builder
+	}
+
+	if deviceClassName == "" {
+		builder.errorMsg = "device request 'deviceClassName' cannot be empty"
+
+		return builder
+	}
+
+	if count < 1 {
+		builder.errorMsg = "device request 'count' must be at least 1"
+
+		return builder
+	}
+
+	klog.V(100).Infof("Adding device request %s (class: %s, count: %d) to ResourceClaimTemplate %s",
+		requestName, deviceClassName, count, builder.Definition.Name)
+
+	request := resourcev1.DeviceRequest{
+		Name: requestName,
+		FirstAvailable: []resourcev1.DeviceSubRequest{
+			{
+				Name:            requestName + "-subrequest",
+				DeviceClassName: deviceClassName,
+				Count:           count,
+			},
+		},
+	}
+
+	builder.Definition.Spec.Spec.Devices.Requests = append(
+		builder.Definition.Spec.Spec.Devices.Requests, request)
+
+	return builder
+}
+
+// PullResourceClaimTemplate pulls an existing ResourceClaimTemplate from the cluster.
+func PullResourceClaimTemplate(
+	apiClient *clients.Settings, name, namespace string) (*ResourceClaimTemplateBuilder, error) {
+	klog.V(100).Infof("Pulling existing ResourceClaimTemplate %s from namespace %s", name, namespace)
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient is empty")
+
+		return nil, fmt.Errorf("resourceClaimTemplate 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(resourcev1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add resource v1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	builder := &ResourceClaimTemplateBuilder{
+		apiClient: apiClient.Client,
+		Definition: &resourcev1.ResourceClaimTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("resourceClaimTemplate 'name' cannot be empty")
+	}
+
+	if namespace == "" {
+		return nil, fmt.Errorf("resourceClaimTemplate 'namespace' cannot be empty")
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf(
+			"resourceClaimTemplate object %s does not exist in namespace %s", name, namespace)
+	}
+
+	builder.Definition = builder.Object
+
+	return builder, nil
+}
+
+// Create builds the ResourceClaimTemplate in the cluster.
+func (builder *ResourceClaimTemplateBuilder) Create() (*ResourceClaimTemplateBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	klog.V(100).Infof("Creating ResourceClaimTemplate %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	if !builder.Exists() {
+		err = builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
+		if err == nil {
+			builder.Object = builder.Definition
+		}
+	}
+
+	return builder, err
+}
+
+// Delete removes the ResourceClaimTemplate from the cluster.
+func (builder *ResourceClaimTemplateBuilder) Delete() (*ResourceClaimTemplateBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	klog.V(100).Infof("Deleting ResourceClaimTemplate %s from namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	if !builder.Exists() {
+		klog.V(100).Info("ResourceClaimTemplate cannot be deleted because it does not exist")
+
+		builder.Object = nil
+
+		return builder, nil
+	}
+
+	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
+	if err != nil {
+		return builder, err
+	}
+
+	builder.Object = nil
+
+	return builder, nil
+}
+
+// Exists checks whether the given ResourceClaimTemplate exists.
+func (builder *ResourceClaimTemplateBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	klog.V(100).Infof("Checking if ResourceClaimTemplate %s exists in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Get fetches the defined ResourceClaimTemplate from the cluster.
+func (builder *ResourceClaimTemplateBuilder) Get() (*resourcev1.ResourceClaimTemplate, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	klog.V(100).Infof("Getting ResourceClaimTemplate %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	rct := &resourcev1.ResourceClaimTemplate{}
+
+	err := builder.apiClient.Get(logging.DiscardContext(), goclient.ObjectKey{
+		Name:      builder.Definition.Name,
+		Namespace: builder.Definition.Namespace,
+	}, rct)
+	if err != nil {
+		return nil, err
+	}
+
+	return rct, nil
+}
+
+// validate checks that the builder is properly configured.
+func (builder *ResourceClaimTemplateBuilder) validate() (bool, error) {
+	resourceCRD := "ResourceClaimTemplate"
+
+	if builder == nil {
+		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		klog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf("%s", builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/pkg/resource/resourceclaimtemplate.go
+++ b/pkg/resource/resourceclaimtemplate.go
@@ -103,7 +103,7 @@ func (builder *ResourceClaimTemplateBuilder) WithDeviceRequest(
 		Name: requestName,
 		FirstAvailable: []resourcev1.DeviceSubRequest{
 			{
-				Name:            requestName + "-subrequest",
+				Name:            "default",
 				DeviceClassName: deviceClassName,
 				Count:           count,
 			},

--- a/pkg/resource/resourceclaimtemplate.go
+++ b/pkg/resource/resourceclaimtemplate.go
@@ -13,6 +13,11 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	errRCTNameEmpty      = "ResourceClaimTemplate 'name' cannot be empty"
+	errRCTNamespaceEmpty = "ResourceClaimTemplate 'namespace' cannot be empty"
+)
+
 // ResourceClaimTemplateBuilder provides struct for the ResourceClaimTemplate object
 // containing connection to the cluster and the ResourceClaimTemplate definitions.
 type ResourceClaimTemplateBuilder struct {
@@ -55,7 +60,7 @@ func NewResourceClaimTemplateBuilder(
 	if name == "" {
 		klog.V(100).Info("The name of the ResourceClaimTemplate is empty")
 
-		builder.errorMsg = "ResourceClaimTemplate 'name' cannot be empty"
+		builder.errorMsg = errRCTNameEmpty
 
 		return builder
 	}
@@ -63,7 +68,7 @@ func NewResourceClaimTemplateBuilder(
 	if namespace == "" {
 		klog.V(100).Info("The namespace of the ResourceClaimTemplate is empty")
 
-		builder.errorMsg = "ResourceClaimTemplate 'namespace' cannot be empty"
+		builder.errorMsg = errRCTNamespaceEmpty
 
 		return builder
 	}

--- a/pkg/resource/resourceclaimtemplate_test.go
+++ b/pkg/resource/resourceclaimtemplate_test.go
@@ -1,0 +1,342 @@
+package resource
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	defaultRCTName      = "test-rct"
+	defaultRCTNamespace = "test-ns"
+)
+
+func TestNewResourceClaimTemplateBuilder(t *testing.T) {
+	testCases := []struct {
+		name        string
+		namespace   string
+		expectedErr string
+		client      bool
+	}{
+		{
+			name:        defaultRCTName,
+			namespace:   defaultRCTNamespace,
+			expectedErr: "",
+			client:      true,
+		},
+		{
+			name:        "",
+			namespace:   defaultRCTNamespace,
+			expectedErr: "ResourceClaimTemplate 'name' cannot be empty",
+			client:      true,
+		},
+		{
+			name:        defaultRCTName,
+			namespace:   "",
+			expectedErr: "ResourceClaimTemplate 'namespace' cannot be empty",
+			client:      true,
+		},
+		{
+			name:        defaultRCTName,
+			namespace:   defaultRCTNamespace,
+			expectedErr: "",
+			client:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				SchemeAttachers: testResourceSchemes,
+			})
+		}
+
+		testBuilder := NewResourceClaimTemplateBuilder(testSettings, testCase.name, testCase.namespace)
+
+		switch {
+		case !testCase.client:
+			assert.Nil(t, testBuilder)
+		case testCase.expectedErr == "":
+			assert.NotNil(t, testBuilder)
+			assert.Equal(t, testCase.name, testBuilder.Definition.Name)
+			assert.Equal(t, testCase.namespace, testBuilder.Definition.Namespace)
+			assert.Empty(t, testBuilder.errorMsg)
+		default:
+			assert.NotNil(t, testBuilder)
+			assert.Equal(t, testCase.expectedErr, testBuilder.errorMsg)
+		}
+	}
+}
+
+func TestWithDeviceRequest(t *testing.T) {
+	testCases := []struct {
+		requestName     string
+		deviceClassName string
+		count           int64
+		expectedErr     string
+	}{
+		{
+			requestName:     "test-request",
+			deviceClassName: "test-class",
+			count:           1,
+			expectedErr:     "",
+		},
+		{
+			requestName:     "",
+			deviceClassName: "test-class",
+			count:           1,
+			expectedErr:     "device request 'name' cannot be empty",
+		},
+		{
+			requestName:     "test-request",
+			deviceClassName: "",
+			count:           1,
+			expectedErr:     "device request 'deviceClassName' cannot be empty",
+		},
+		{
+			requestName:     "test-request",
+			deviceClassName: "test-class",
+			count:           0,
+			expectedErr:     "device request 'count' must be at least 1",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidResourceClaimTemplate()
+		testBuilder.WithDeviceRequest(testCase.requestName, testCase.deviceClassName, testCase.count)
+
+		assert.Equal(t, testCase.expectedErr, testBuilder.errorMsg)
+
+		if testCase.expectedErr == "" {
+			assert.Len(t, testBuilder.Definition.Spec.Spec.Devices.Requests, 1)
+			assert.Equal(t, testCase.requestName,
+				testBuilder.Definition.Spec.Spec.Devices.Requests[0].Name)
+		}
+	}
+}
+
+func TestWithDeviceRequestSubrequestName(t *testing.T) {
+	testBuilder := buildValidResourceClaimTemplate()
+	testBuilder.WithDeviceRequest("my-request", "test-class", 1)
+
+	assert.Empty(t, testBuilder.errorMsg)
+	assert.Len(t, testBuilder.Definition.Spec.Spec.Devices.Requests, 1)
+
+	request := testBuilder.Definition.Spec.Spec.Devices.Requests[0]
+	assert.Len(t, request.FirstAvailable, 1)
+	assert.Equal(t, "default", request.FirstAvailable[0].Name)
+}
+
+func TestWithDeviceRequestMultiple(t *testing.T) {
+	testBuilder := buildValidResourceClaimTemplate()
+	testBuilder.WithDeviceRequest("request-1", "class-1", 1)
+	testBuilder.WithDeviceRequest("request-2", "class-2", 2)
+
+	assert.Empty(t, testBuilder.errorMsg)
+	assert.Len(t, testBuilder.Definition.Spec.Spec.Devices.Requests, 2)
+}
+
+func TestWithDeviceRequestInvalidBuilder(t *testing.T) {
+	testBuilder := buildInvalidResourceClaimTemplate()
+	origErr := testBuilder.errorMsg
+
+	testBuilder.WithDeviceRequest("test", "test-class", 1)
+	assert.Equal(t, origErr, testBuilder.errorMsg)
+}
+
+func TestPullResourceClaimTemplate(t *testing.T) {
+	testCases := []struct {
+		name                string
+		namespace           string
+		expectedError       error
+		addToRuntimeObjects bool
+		client              bool
+	}{
+		{
+			name:                defaultRCTName,
+			namespace:           defaultRCTNamespace,
+			expectedError:       nil,
+			addToRuntimeObjects: true,
+			client:              true,
+		},
+		{
+			name:                "",
+			namespace:           defaultRCTNamespace,
+			expectedError:       fmt.Errorf("resourceClaimTemplate 'name' cannot be empty"),
+			addToRuntimeObjects: true,
+			client:              true,
+		},
+		{
+			name:                defaultRCTName,
+			namespace:           "",
+			expectedError:       fmt.Errorf("resourceClaimTemplate 'namespace' cannot be empty"),
+			addToRuntimeObjects: true,
+			client:              true,
+		},
+		{
+			name:      defaultRCTName,
+			namespace: defaultRCTNamespace,
+			expectedError: fmt.Errorf(
+				"resourceClaimTemplate object %s does not exist in namespace %s",
+				defaultRCTName, defaultRCTNamespace),
+			addToRuntimeObjects: false,
+			client:              true,
+		},
+		{
+			name:                defaultRCTName,
+			namespace:           defaultRCTNamespace,
+			expectedError:       fmt.Errorf("resourceClaimTemplate 'apiClient' cannot be nil"),
+			addToRuntimeObjects: true,
+			client:              false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects,
+				generateResourceClaimTemplate(testCase.name, testCase.namespace))
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: testResourceSchemes,
+			})
+		}
+
+		builderResult, err := PullResourceClaimTemplate(testSettings, testCase.name, testCase.namespace)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.NotNil(t, builderResult)
+			assert.Equal(t, testCase.name, builderResult.Definition.Name)
+		}
+	}
+}
+
+func TestResourceClaimTemplateCreate(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *ResourceClaimTemplateBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   buildValidResourceClaimTemplate(),
+			expectedError: "",
+		},
+		{
+			testBuilder:   buildInvalidResourceClaimTemplate(),
+			expectedError: "ResourceClaimTemplate 'name' cannot be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, err := testCase.testBuilder.Create()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.NotNil(t, result.Object)
+			assert.Equal(t, result.Definition.Name, result.Object.Name)
+		} else {
+			assert.NotNil(t, err)
+			assert.Equal(t, testCase.expectedError, err.Error())
+		}
+	}
+}
+
+func TestResourceClaimTemplateDelete(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *ResourceClaimTemplateBuilder
+		expectedError error
+	}{
+		{
+			testBuilder:   buildValidResourceClaimTemplateWithDummyObject(),
+			expectedError: nil,
+		},
+		{
+			testBuilder:   buildInvalidResourceClaimTemplate(),
+			expectedError: fmt.Errorf("ResourceClaimTemplate 'name' cannot be empty"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		_, err := testCase.testBuilder.Delete()
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Nil(t, testCase.testBuilder.Object)
+		}
+	}
+}
+
+func TestResourceClaimTemplateExists(t *testing.T) {
+	testCases := []struct {
+		testBuilder    *ResourceClaimTemplateBuilder
+		expectedStatus bool
+	}{
+		{
+			testBuilder:    buildValidResourceClaimTemplateWithDummyObject(),
+			expectedStatus: true,
+		},
+		{
+			testBuilder:    buildInvalidResourceClaimTemplate(),
+			expectedStatus: false,
+		},
+		{
+			testBuilder:    buildValidResourceClaimTemplate(),
+			expectedStatus: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		exist := testCase.testBuilder.Exists()
+		assert.Equal(t, testCase.expectedStatus, exist)
+	}
+}
+
+func buildValidResourceClaimTemplate() *ResourceClaimTemplateBuilder {
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		SchemeAttachers: testResourceSchemes,
+	})
+
+	return NewResourceClaimTemplateBuilder(testSettings, defaultRCTName, defaultRCTNamespace)
+}
+
+func buildValidResourceClaimTemplateWithDummyObject() *ResourceClaimTemplateBuilder {
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: []runtime.Object{
+			generateResourceClaimTemplate(defaultRCTName, defaultRCTNamespace),
+		},
+		SchemeAttachers: testResourceSchemes,
+	})
+
+	return NewResourceClaimTemplateBuilder(testSettings, defaultRCTName, defaultRCTNamespace)
+}
+
+func buildInvalidResourceClaimTemplate() *ResourceClaimTemplateBuilder {
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		SchemeAttachers: testResourceSchemes,
+	})
+
+	return NewResourceClaimTemplateBuilder(testSettings, "", defaultRCTNamespace)
+}
+
+func generateResourceClaimTemplate(name, namespace string) *resourcev1.ResourceClaimTemplate {
+	return &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/pkg/resource/resourceclaimtemplate_test.go
+++ b/pkg/resource/resourceclaimtemplate_test.go
@@ -32,7 +32,7 @@ func TestNewResourceClaimTemplateBuilder(t *testing.T) {
 		{
 			name:        "",
 			namespace:   defaultRCTNamespace,
-			expectedErr: "ResourceClaimTemplate 'name' cannot be empty",
+			expectedErr: errRCTNameEmpty,
 			client:      true,
 		},
 		{
@@ -237,7 +237,7 @@ func TestResourceClaimTemplateCreate(t *testing.T) {
 		},
 		{
 			testBuilder:   buildInvalidResourceClaimTemplate(),
-			expectedError: "ResourceClaimTemplate 'name' cannot be empty",
+			expectedError: errRCTNameEmpty,
 		},
 	}
 
@@ -266,7 +266,7 @@ func TestResourceClaimTemplateDelete(t *testing.T) {
 		},
 		{
 			testBuilder:   buildInvalidResourceClaimTemplate(),
-			expectedError: fmt.Errorf("ResourceClaimTemplate 'name' cannot be empty"),
+			expectedError: fmt.Errorf(errRCTNameEmpty),
 		},
 	}
 

--- a/pkg/resource/resourceslice.go
+++ b/pkg/resource/resourceslice.go
@@ -1,64 +1,58 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ListResourceSlices returns ResourceSlice objects matching the given options.
-func ListResourceSlices(
-	apiClient *clients.Settings,
-	options ...goclient.ListOption) ([]resourcev1.ResourceSlice, error) {
-	klog.V(100).Info("Listing ResourceSlices")
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("resourceSlice 'apiClient' cannot be nil")
-	}
-
-	err := apiClient.AttachScheme(resourcev1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add resource v1 scheme to client schemes")
-
-		return nil, err
-	}
-
-	sliceList := &resourcev1.ResourceSliceList{}
-
-	err = apiClient.List(logging.DiscardContext(), sliceList, options...)
-	if err != nil {
-		return nil, err
-	}
-
-	return sliceList.Items, nil
+// ResourceSliceBuilder provides a struct for the ResourceSlice resource containing a connection
+// to the cluster and the ResourceSlice definitions.
+type ResourceSliceBuilder struct {
+	common.EmbeddableBuilder[resourcev1.ResourceSlice, *resourcev1.ResourceSlice]
 }
 
-// ListResourceSlicesByDriver returns ResourceSlice objects filtered by driver name.
+// GetGVK returns the ResourceSlice GVK for this builder.
+func (builder *ResourceSliceBuilder) GetGVK() schema.GroupVersionKind {
+	return resourcev1.SchemeGroupVersion.WithKind("ResourceSlice")
+}
+
+// ListResourceSlices returns ResourceSlice builders matching the given options.
+func ListResourceSlices(
+	apiClient *clients.Settings,
+	options ...runtimeclient.ListOption) ([]*ResourceSliceBuilder, error) {
+	klog.V(100).Info("Listing ResourceSlices")
+
+	return common.List[resourcev1.ResourceSlice, resourcev1.ResourceSliceList, ResourceSliceBuilder](
+		context.TODO(), apiClient, resourcev1.AddToScheme, options...)
+}
+
+// ListResourceSlicesByDriver returns ResourceSlice builders filtered by driver name.
 func ListResourceSlicesByDriver(
 	apiClient *clients.Settings,
-	driverName string) ([]resourcev1.ResourceSlice, error) {
+	driverName string) ([]*ResourceSliceBuilder, error) {
 	klog.V(100).Infof("Listing ResourceSlices for driver %s", driverName)
 
 	if driverName == "" {
 		return nil, fmt.Errorf("resourceSlice 'driverName' cannot be empty")
 	}
 
-	allSlices, err := ListResourceSlices(apiClient)
+	allBuilders, err := ListResourceSlices(apiClient)
 	if err != nil {
 		return nil, err
 	}
 
-	var filtered []resourcev1.ResourceSlice
+	var filtered []*ResourceSliceBuilder
 
-	for idx := range allSlices {
-		if allSlices[idx].Spec.Driver == driverName {
-			filtered = append(filtered, allSlices[idx])
+	for _, builder := range allBuilders {
+		if builder.Object.Spec.Driver == driverName {
+			filtered = append(filtered, builder)
 		}
 	}
 

--- a/pkg/resource/resourceslice.go
+++ b/pkg/resource/resourceslice.go
@@ -1,0 +1,66 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/klog/v2"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListResourceSlices returns ResourceSlice objects matching the given options.
+func ListResourceSlices(
+	apiClient *clients.Settings,
+	options ...goclient.ListOption) ([]resourcev1.ResourceSlice, error) {
+	klog.V(100).Info("Listing ResourceSlices")
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient is empty")
+
+		return nil, fmt.Errorf("resourceSlice 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(resourcev1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add resource v1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	sliceList := &resourcev1.ResourceSliceList{}
+
+	err = apiClient.List(logging.DiscardContext(), sliceList, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return sliceList.Items, nil
+}
+
+// ListResourceSlicesByDriver returns ResourceSlice objects filtered by driver name.
+func ListResourceSlicesByDriver(
+	apiClient *clients.Settings,
+	driverName string) ([]resourcev1.ResourceSlice, error) {
+	klog.V(100).Infof("Listing ResourceSlices for driver %s", driverName)
+
+	if driverName == "" {
+		return nil, fmt.Errorf("resourceSlice 'driverName' cannot be empty")
+	}
+
+	allSlices, err := ListResourceSlices(apiClient)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []resourcev1.ResourceSlice
+
+	for idx := range allSlices {
+		if allSlices[idx].Spec.Driver == driverName {
+			filtered = append(filtered, allSlices[idx])
+		}
+	}
+
+	return filtered, nil
+}

--- a/pkg/resource/resourceslice_test.go
+++ b/pkg/resource/resourceslice_test.go
@@ -23,6 +23,21 @@ func TestListResourceSlices(t *testing.T) {
 	).ExecuteTests(t)
 }
 
+func TestResourceSliceBuilderMethods(t *testing.T) {
+	t.Parallel()
+
+	commonTestConfig := testhelper.NewCommonTestConfig[resourcev1.ResourceSlice, ResourceSliceBuilder](
+		resourcev1.AddToScheme,
+		resourceSliceGVK,
+		testhelper.ResourceScopeClusterScoped,
+	)
+
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		Run(t)
+}
+
 func TestListResourceSlicesByDriver(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/pkg/resource/resourceslice_test.go
+++ b/pkg/resource/resourceslice_test.go
@@ -1,0 +1,142 @@
+package resource
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestListResourceSlices(t *testing.T) {
+	testCases := []struct {
+		addToRuntimeObjects bool
+		expectedCount       int
+		client              bool
+		expectedError       error
+	}{
+		{
+			addToRuntimeObjects: true,
+			expectedCount:       1,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			addToRuntimeObjects: false,
+			expectedCount:       0,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			addToRuntimeObjects: true,
+			expectedCount:       0,
+			client:              false,
+			expectedError:       fmt.Errorf("resourceSlice 'apiClient' cannot be nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects,
+				generateResourceSlice("test-slice", "test-driver"))
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: testResourceSchemes,
+			})
+		}
+
+		slices, err := ListResourceSlices(testSettings)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Len(t, slices, testCase.expectedCount)
+		}
+	}
+}
+
+func TestListResourceSlicesByDriver(t *testing.T) {
+	testCases := []struct {
+		driverName    string
+		addSlices     bool
+		client        bool
+		expectedCount int
+		expectedError error
+	}{
+		{
+			driverName:    "test-driver",
+			addSlices:     true,
+			client:        true,
+			expectedCount: 1,
+			expectedError: nil,
+		},
+		{
+			driverName:    "other-driver",
+			addSlices:     true,
+			client:        true,
+			expectedCount: 0,
+			expectedError: nil,
+		},
+		{
+			driverName:    "",
+			addSlices:     false,
+			client:        true,
+			expectedCount: 0,
+			expectedError: fmt.Errorf("resourceSlice 'driverName' cannot be empty"),
+		},
+		{
+			driverName:    "test-driver",
+			addSlices:     false,
+			client:        false,
+			expectedCount: 0,
+			expectedError: fmt.Errorf("resourceSlice 'apiClient' cannot be nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addSlices {
+			runtimeObjects = append(runtimeObjects,
+				generateResourceSlice("test-slice", "test-driver"))
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: testResourceSchemes,
+			})
+		}
+
+		slices, err := ListResourceSlicesByDriver(testSettings, testCase.driverName)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Len(t, slices, testCase.expectedCount)
+		}
+	}
+}
+
+func generateResourceSlice(name, driverName string) *resourcev1.ResourceSlice {
+	return &resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver: driverName,
+		},
+	}
+}

--- a/pkg/resource/resourceslice_test.go
+++ b/pkg/resource/resourceslice_test.go
@@ -1,133 +1,99 @@
 package resource
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var resourceSliceGVK = resourcev1.SchemeGroupVersion.WithKind("ResourceSlice")
+
 func TestListResourceSlices(t *testing.T) {
-	testCases := []struct {
-		addToRuntimeObjects bool
-		expectedCount       int
-		client              bool
-		expectedError       error
-	}{
-		{
-			addToRuntimeObjects: true,
-			expectedCount:       1,
-			client:              true,
-			expectedError:       nil,
-		},
-		{
-			addToRuntimeObjects: false,
-			expectedCount:       0,
-			client:              true,
-			expectedError:       nil,
-		},
-		{
-			addToRuntimeObjects: true,
-			expectedCount:       0,
-			client:              false,
-			expectedError:       fmt.Errorf("resourceSlice 'apiClient' cannot be nil"),
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects,
-				generateResourceSlice("test-slice", "test-driver"))
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: testResourceSchemes,
-			})
-		}
-
-		slices, err := ListResourceSlices(testSettings)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Len(t, slices, testCase.expectedCount)
-		}
-	}
+	testhelper.NewListTestConfig(
+		ListResourceSlices,
+		resourcev1.AddToScheme,
+		resourceSliceGVK,
+	).ExecuteTests(t)
 }
 
 func TestListResourceSlicesByDriver(t *testing.T) {
 	testCases := []struct {
+		name          string
 		driverName    string
 		addSlices     bool
 		client        bool
 		expectedCount int
-		expectedError error
+		expectedError bool
 	}{
 		{
+			name:          "matching driver",
 			driverName:    "test-driver",
 			addSlices:     true,
 			client:        true,
 			expectedCount: 1,
-			expectedError: nil,
 		},
 		{
+			name:          "non-matching driver",
 			driverName:    "other-driver",
 			addSlices:     true,
 			client:        true,
 			expectedCount: 0,
-			expectedError: nil,
 		},
 		{
+			name:          "empty driverName",
 			driverName:    "",
-			addSlices:     false,
 			client:        true,
-			expectedCount: 0,
-			expectedError: fmt.Errorf("resourceSlice 'driverName' cannot be empty"),
+			expectedError: true,
 		},
 		{
+			name:          "nil apiClient",
 			driverName:    "test-driver",
-			addSlices:     false,
 			client:        false,
-			expectedCount: 0,
-			expectedError: fmt.Errorf("resourceSlice 'apiClient' cannot be nil"),
+			expectedError: true,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
+		t.Run(testCase.name, func(t *testing.T) {
+			var (
+				runtimeObjects []runtime.Object
+				testSettings   *clients.Settings
+			)
 
-		if testCase.addSlices {
-			runtimeObjects = append(runtimeObjects,
-				generateResourceSlice("test-slice", "test-driver"))
-		}
+			if testCase.addSlices {
+				runtimeObjects = append(runtimeObjects,
+					generateResourceSlice("test-slice", "test-driver"))
+			}
 
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: testResourceSchemes,
-			})
-		}
+			if testCase.client {
+				testSettings = clients.GetTestClients(clients.TestClientParams{
+					K8sMockObjects:  runtimeObjects,
+					SchemeAttachers: testResourceSchemes,
+				})
+			}
 
-		slices, err := ListResourceSlicesByDriver(testSettings, testCase.driverName)
-		assert.Equal(t, testCase.expectedError, err)
+			builders, err := ListResourceSlicesByDriver(testSettings, testCase.driverName)
 
-		if testCase.expectedError == nil {
-			assert.Len(t, slices, testCase.expectedCount)
-		}
+			if testCase.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, builders, testCase.expectedCount)
+			}
+		})
 	}
+}
+
+func TestResourceSliceBuilderGetGVK(t *testing.T) {
+	builder := &ResourceSliceBuilder{}
+	assert.Equal(t, resourceSliceGVK, builder.GetGVK())
 }
 
 func generateResourceSlice(name, driverName string) *resourcev1.ResourceSlice {


### PR DESCRIPTION
## Summary

- Add DRA mode support to the Neuron DeviceConfig builder (`NewBuilderWithDRA`, `NewBuilderWithInClusterBuildDRA`, `WithDRADriverImage`, `WithDeviceClasses`)
- Add `ResourceClaimTemplateBuilder` for creating DRA ResourceClaimTemplates in e2e tests
- Add `ListResourceClaims`, `GetResourceClaim` helpers for ResourceClaim verification
- Add `ListResourceSlices`, `ListResourceSlicesByDriver` helpers for ResourceSlice verification

These builders are needed for Neuron DRA e2e tests following the KMM 2.7 DRA migration (awslabs/operator-for-ai-chips-on-aws#89).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring DRA drivers, images, and device classes.
  * Added builder-based tools to list and retrieve resource claims.
  * Added tools to create, delete, inspect, and retrieve resource claim templates.
  * Added utilities to list resource slices and filter them by driver.
* **Validation**
  * Added clear validation for missing or invalid configuration and resource details.
* **Tests**
  * Expanded coverage for resource claim, template, and slice operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->