### PR TITLE
hw-accel: Add WithCommand and WithResourceClaim to pod builder

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -1263,6 +1263,96 @@ func (builder *Builder) WithTerminationGracePeriodSeconds(terminationGracePeriod
 	return builder
 }
 
+// WithCommand sets the command for the first container in the pod spec.
+func (builder *Builder) WithCommand(command []string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Setting command %v on pod %s in namespace %s",
+		command, builder.Definition.Name, builder.Definition.Namespace)
+
+	builder.isMutationAllowed("command")
+
+	if builder.errorMsg != "" {
+		return builder
+	}
+
+	if len(command) == 0 {
+		klog.V(100).Infof("Failed to set command on pod %s: command cannot be empty",
+			builder.Definition.Name)
+
+		builder.errorMsg = "pod command cannot be empty"
+
+		return builder
+	}
+
+	if len(builder.Definition.Spec.Containers) == 0 {
+		klog.V(100).Infof("Failed to set command on pod %s: no containers defined",
+			builder.Definition.Name)
+
+		builder.errorMsg = "pod has no containers to set command on"
+
+		return builder
+	}
+
+	builder.Definition.Spec.Containers[0].Command = command
+
+	return builder
+}
+
+// WithResourceClaim adds a ResourceClaim to the pod that references a ResourceClaimTemplate.
+func (builder *Builder) WithResourceClaim(claimName, claimTemplateName string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Adding ResourceClaim %s (template: %s) to pod %s in namespace %s",
+		claimName, claimTemplateName, builder.Definition.Name, builder.Definition.Namespace)
+
+	builder.isMutationAllowed("ResourceClaim")
+
+	if builder.errorMsg != "" {
+		return builder
+	}
+
+	if claimName == "" {
+		builder.errorMsg = "ResourceClaim name cannot be empty"
+
+		return builder
+	}
+
+	if claimTemplateName == "" {
+		builder.errorMsg = "ResourceClaimTemplate name cannot be empty"
+
+		return builder
+	}
+
+	for _, existing := range builder.Definition.Spec.ResourceClaims {
+		if existing.Name == claimName {
+			klog.V(100).Infof("ResourceClaim %s already exists on pod %s, skipping",
+				claimName, builder.Definition.Name)
+
+			return builder
+		}
+	}
+
+	builder.Definition.Spec.ResourceClaims = append(
+		builder.Definition.Spec.ResourceClaims,
+		corev1.PodResourceClaim{
+			Name:                      claimName,
+			ResourceClaimTemplateName: &claimTemplateName,
+		})
+
+	if len(builder.Definition.Spec.Containers) > 0 {
+		builder.Definition.Spec.Containers[0].Resources.Claims = append(
+			builder.Definition.Spec.Containers[0].Resources.Claims,
+			corev1.ResourceClaim{Name: claimName})
+	}
+
+	return builder
+}
+
 // GetLog connects to a pod and fetches log.
 func (builder *Builder) GetLog(logStartTime time.Duration, containerName string) (string, error) {
 	// GetLogsWithOptions already handles validation, so no need to duplicate it here.

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -909,6 +909,138 @@ func buildTestClientWithDummyPod() *clients.Settings {
 	})
 }
 
+func TestPodWithCommand(t *testing.T) {
+	testCases := []struct {
+		command       []string
+		hasObject     bool
+		expectedError string
+	}{
+		{
+			command:       []string{"sleep", "infinity"},
+			hasObject:     false,
+			expectedError: "",
+		},
+		{
+			command:       []string{},
+			hasObject:     false,
+			expectedError: "pod command cannot be empty",
+		},
+		{
+			command:       []string{"sleep", "infinity"},
+			hasObject:     true,
+			expectedError: podRunningErrorMsg,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidPodTestBuilder(buildTestClientWithDummyPod())
+
+		if testCase.hasObject {
+			testBuilder.Object = testBuilder.Definition
+			testBuilder.Object.Spec.NodeName = defaultPodNodeName
+		}
+
+		result := testBuilder.WithCommand(testCase.command)
+
+		if testCase.expectedError == "" {
+			assert.Equal(t, testCase.command, result.Definition.Spec.Containers[0].Command)
+		} else {
+			assert.Equal(t, testCase.expectedError, result.errorMsg)
+		}
+	}
+}
+
+func TestPodWithCommandNoContainers(t *testing.T) {
+	testBuilder := buildValidPodTestBuilder(buildTestClientWithDummyPod())
+	testBuilder.Definition.Spec.Containers = nil
+
+	result := testBuilder.WithCommand([]string{"sleep", "infinity"})
+	assert.Equal(t, "pod has no containers to set command on", result.errorMsg)
+}
+
+func TestPodWithResourceClaim(t *testing.T) {
+	testCases := []struct {
+		claimName         string
+		claimTemplateName string
+		hasObject         bool
+		expectedError     string
+	}{
+		{
+			claimName:         "test-claim",
+			claimTemplateName: "test-template",
+			hasObject:         false,
+			expectedError:     "",
+		},
+		{
+			claimName:         "",
+			claimTemplateName: "test-template",
+			hasObject:         false,
+			expectedError:     "ResourceClaim name cannot be empty",
+		},
+		{
+			claimName:         "test-claim",
+			claimTemplateName: "",
+			hasObject:         false,
+			expectedError:     "ResourceClaimTemplate name cannot be empty",
+		},
+		{
+			claimName:         "test-claim",
+			claimTemplateName: "test-template",
+			hasObject:         true,
+			expectedError:     podRunningErrorMsg,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidPodTestBuilder(buildTestClientWithDummyPod())
+
+		if testCase.hasObject {
+			testBuilder.Object = testBuilder.Definition
+			testBuilder.Object.Spec.NodeName = defaultPodNodeName
+		}
+
+		result := testBuilder.WithResourceClaim(testCase.claimName, testCase.claimTemplateName)
+
+		if testCase.expectedError == "" {
+			assert.Len(t, result.Definition.Spec.ResourceClaims, 1)
+			assert.Equal(t, testCase.claimName, result.Definition.Spec.ResourceClaims[0].Name)
+			assert.Equal(t, testCase.claimTemplateName,
+				*result.Definition.Spec.ResourceClaims[0].ResourceClaimTemplateName)
+			assert.Len(t, result.Definition.Spec.Containers[0].Resources.Claims, 1)
+			assert.Equal(t, testCase.claimName,
+				result.Definition.Spec.Containers[0].Resources.Claims[0].Name)
+		} else {
+			assert.Equal(t, testCase.expectedError, result.errorMsg)
+		}
+	}
+}
+
+func TestPodWithResourceClaimDuplicate(t *testing.T) {
+	testBuilder := buildValidPodTestBuilder(buildTestClientWithDummyPod())
+
+	result := testBuilder.
+		WithResourceClaim("claim-a", "template-a").
+		WithResourceClaim("claim-a", "template-a")
+
+	assert.Len(t, result.Definition.Spec.ResourceClaims, 1,
+		"Duplicate claim name should not create a second entry")
+	assert.Len(t, result.Definition.Spec.Containers[0].Resources.Claims, 1)
+}
+
+func TestPodWithResourceClaimDistinct(t *testing.T) {
+	testBuilder := buildValidPodTestBuilder(buildTestClientWithDummyPod())
+
+	result := testBuilder.
+		WithResourceClaim("claim-a", "template-a").
+		WithResourceClaim("claim-b", "template-b")
+
+	assert.Len(t, result.Definition.Spec.ResourceClaims, 2,
+		"Distinct claim names should create separate entries")
+	assert.Equal(t, "claim-a", result.Definition.Spec.ResourceClaims[0].Name)
+	assert.Equal(t, "claim-b", result.Definition.Spec.ResourceClaims[1].Name)
+	assert.Len(t, result.Definition.Spec.Containers[0].Resources.Claims, 2)
+}
+
 // buildValidPodTestBuilder returns a valid Pod builder for testing.
 func buildValidPodTestBuilder(apiClient *clients.Settings) *Builder {
 	return NewBuilder(apiClient, defaultPodName, defaultPodNsName, defaultPodImage)


### PR DESCRIPTION
## Summary
- Add `WithCommand(command []string)` to set the first container's command via builder chaining
- Add `WithResourceClaim(claimName, claimTemplateName string)` to add a DRA ResourceClaim referencing a ResourceClaimTemplate, including the container resource claim entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added builder options to configure a container’s startup command.
  * Added support for attaching resource claims to pods and associating them with the first container.
  * Added validation for empty commands, missing containers, invalid claim names, and modifications to running pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->