### PR TITLE
add nad bond pluggin sysctl options

### DIFF
--- a/pkg/nad/masterplugin.go
+++ b/pkg/nad/masterplugin.go
@@ -12,6 +12,12 @@ import (
 const (
 	cniVersion031 = "0.3.1"
 	cniTypeIpvlan = "ipvlan"
+
+	bondModeBalanceRR    = "balance-rr"
+	bondModeActiveBackup = "active-backup"
+	bondModeBalanceXOR   = "balance-xor"
+	bondModeBalanceTLB   = "balance-tlb"
+	bondModeBalanceALB   = "balance-alb"
 )
 
 var (
@@ -19,6 +25,14 @@ var (
 	allowedMacVlanMode       = []string{"bridge", "passthru", "private", "vepa"}
 	invalidIpamParameterMsg  = "invalid ipam parameter"
 	invalidXmitHashPolicyMsg = "error adding incorrect xmitHashPolicy value to MasterBondPlugin"
+	// validBondModes represents all allowed modes for bond plugin type.
+	validBondModes = map[string]bool{
+		bondModeBalanceRR:    true,
+		bondModeActiveBackup: true,
+		bondModeBalanceXOR:   true,
+		bondModeBalanceTLB:   true,
+		bondModeBalanceALB:   true,
+	}
 )
 
 // MasterMacVlanPlugin provides struct for NetworkAttachmentDefinition Master plugin with macvlan configuration.
@@ -429,14 +443,6 @@ type MasterBondPlugin struct {
 func NewMasterBondPlugin(name, mode string) *MasterBondPlugin {
 	klog.V(100).Infof("Initializing new NewMasterBondPlugin structure %s and %s", name, mode)
 
-	validModes := map[string]bool{
-		"balance-rr":    true,
-		"active-backup": true,
-		"balance-xor":   true,
-		"balance-tlb":   true,
-		"balance-alb":   true,
-	}
-
 	builder := &MasterBondPlugin{
 		masterPlugin: &MasterPlugin{
 			CniVersion: cniVersion031,
@@ -447,7 +453,7 @@ func NewMasterBondPlugin(name, mode string) *MasterBondPlugin {
 	}
 
 	// Check if the provided mode is valid
-	if !validModes[mode] {
+	if !validBondModes[mode] {
 		klog.V(100).Infof("error: invalid mode type %s used for MasterBondPlugin bond interface", mode)
 
 		builder.errorMsg = "Bond mode type is not valid"

--- a/pkg/nad/masterplugin_test.go
+++ b/pkg/nad/masterplugin_test.go
@@ -49,7 +49,7 @@ func TestMasterBondPluginWithXmitHashPolicy(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			cfg, err := NewMasterBondPlugin("bond0", "balance-xor").
+			cfg, err := NewMasterBondPlugin("bond0", bondModeBalanceXOR).
 				WithXmitHashPolicy(testCase.xmitHashPolicy).
 				GetMasterPluginConfig()
 
@@ -73,7 +73,7 @@ func TestMasterBondPluginWithXmitHashPolicy(t *testing.T) {
 }
 
 func TestMasterBondPluginWithXmitHashPolicyAcceptance(t *testing.T) {
-	cfg, err := NewMasterBondPlugin("bond0", "balance-xor").
+	cfg, err := NewMasterBondPlugin("bond0", bondModeBalanceXOR).
 		WithLinksInContainer(true).
 		WithFailOverMac(1).
 		WithMiimon(100).

--- a/pkg/nad/plugins.go
+++ b/pkg/nad/plugins.go
@@ -27,3 +27,32 @@ func TuningMacPlugin(macCap bool) *Plugin {
 		Capabilities: &Capability{Mac: macCap},
 	}
 }
+
+// BondPluginOptions holds bond plugin fields for BondPlugin.
+type BondPluginOptions struct {
+	FailOverMac      int
+	LinksInContainer bool
+	Miimon           string
+}
+
+// BondPlugin returns bond plugin configuration.
+func BondPlugin(ipam *IPAM, bondPorts []string, bondMode string, opts BondPluginOptions) *Plugin {
+	if !validBondModes[bondMode] {
+		return nil
+	}
+
+	links := make([]Link, 0, len(bondPorts))
+	for _, port := range bondPorts {
+		links = append(links, Link{Name: port})
+	}
+
+	return &Plugin{
+		Type:             "bond",
+		Mode:             bondMode,
+		FailOverMac:      opts.FailOverMac,
+		LinksInContainer: opts.LinksInContainer,
+		Miimon:           opts.Miimon,
+		Ipam:             ipam,
+		Links:            links,
+	}
+}

--- a/pkg/nad/plugins_test.go
+++ b/pkg/nad/plugins_test.go
@@ -1,0 +1,187 @@
+package nad
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var sysctlBondPluginOptions = BondPluginOptions{
+	FailOverMac:      1,
+	LinksInContainer: true,
+	Miimon:           "100",
+}
+
+func TestBondPlugin(t *testing.T) {
+	testCases := []struct {
+		name       string
+		ipam       *IPAM
+		bondPorts  []string
+		bondMode   string
+		opts       BondPluginOptions
+		expectJSON []string
+	}{
+		{
+			name:      "active-backup with static ipam",
+			ipam:      IPAMStatic(),
+			bondPorts: []string{"net1", "net2"},
+			bondMode:  bondModeActiveBackup,
+			opts:      sysctlBondPluginOptions,
+			expectJSON: []string{
+				`"type":"bond"`,
+				fmt.Sprintf(`"mode":%q`, bondModeActiveBackup),
+				`"failOverMac":1`,
+				`"linksInContainer":true`,
+				`"miimon":"100"`,
+				`"ipam":{"type":"static"}`,
+				`"links":[{"name":"net1"},{"name":"net2"}]`,
+			},
+		},
+		{
+			name:      "balance-xor with nil ipam",
+			ipam:      nil,
+			bondPorts: []string{"net4", "net5"},
+			bondMode:  bondModeBalanceXOR,
+			opts:      sysctlBondPluginOptions,
+			expectJSON: []string{
+				`"type":"bond"`,
+				fmt.Sprintf(`"mode":%q`, bondModeBalanceXOR),
+				`"links":[{"name":"net4"},{"name":"net5"}]`,
+			},
+		},
+		{
+			name:      "empty bondPorts",
+			ipam:      IPAMStatic(),
+			bondPorts: []string{},
+			bondMode:  bondModeActiveBackup,
+			opts:      sysctlBondPluginOptions,
+		},
+		{
+			name:      "single bondPort",
+			ipam:      IPAMStatic(),
+			bondPorts: []string{"net1"},
+			bondMode:  bondModeActiveBackup,
+			opts:      sysctlBondPluginOptions,
+			expectJSON: []string{
+				`"links":[{"name":"net1"}]`,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			plugin := BondPlugin(testCase.ipam, testCase.bondPorts, testCase.bondMode, testCase.opts)
+			assertBondPluginFields(t, plugin, testCase.ipam, testCase.bondMode, testCase.bondPorts, testCase.opts)
+			assertBondPluginJSONFields(t, plugin, testCase.expectJSON)
+		})
+	}
+}
+
+func TestBondPluginInvalidMode(t *testing.T) {
+	testCases := []struct {
+		name     string
+		bondMode string
+	}{
+		{name: "invalid bond mode", bondMode: "invalid-mode"},
+		{name: "empty bond mode", bondMode: ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			plugin := BondPlugin(IPAMStatic(), []string{"net1", "net2"}, testCase.bondMode, sysctlBondPluginOptions)
+			assert.Nil(t, plugin)
+		})
+	}
+}
+
+func assertBondPluginFields(
+	t *testing.T,
+	plugin *Plugin,
+	ipam *IPAM,
+	bondMode string,
+	bondPorts []string,
+	opts BondPluginOptions,
+) {
+	t.Helper()
+
+	assert.NotNil(t, plugin)
+	assert.Equal(t, "bond", plugin.Type)
+	assert.Equal(t, bondMode, plugin.Mode)
+	assert.Equal(t, opts.FailOverMac, plugin.FailOverMac)
+	assert.Equal(t, opts.LinksInContainer, plugin.LinksInContainer)
+	assert.Equal(t, opts.Miimon, plugin.Miimon)
+	assert.Equal(t, ipam, plugin.Ipam)
+
+	expectedLinks := make([]Link, 0, len(bondPorts))
+	for _, port := range bondPorts {
+		expectedLinks = append(expectedLinks, Link{Name: port})
+	}
+
+	assert.Equal(t, expectedLinks, plugin.Links)
+}
+
+func assertBondPluginJSONFields(t *testing.T, plugin *Plugin, expectJSON []string) {
+	t.Helper()
+
+	if len(expectJSON) == 0 {
+		return
+	}
+
+	marshaled, err := json.Marshal(plugin)
+	assert.NoError(t, err)
+
+	marshaledJSON := string(marshaled)
+	for _, expectedField := range expectJSON {
+		assert.Contains(t, marshaledJSON, expectedField)
+	}
+}
+
+func TestBondPluginOptions(t *testing.T) {
+	opts := BondPluginOptions{
+		FailOverMac:      2,
+		LinksInContainer: false,
+		Miimon:           "200",
+	}
+
+	plugin := BondPlugin(
+		IPAMStatic(),
+		[]string{"net1", "net2"},
+		bondModeActiveBackup,
+		opts,
+	)
+
+	assert.NotNil(t, plugin)
+	assert.Equal(t, 2, plugin.FailOverMac)
+	assert.False(t, plugin.LinksInContainer)
+	assert.Equal(t, "200", plugin.Miimon)
+
+	marshaled, err := json.Marshal(plugin)
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshaled), `"failOverMac":2`)
+	assert.Contains(t, string(marshaled), `"miimon":"200"`)
+	assert.NotContains(t, string(marshaled), `"linksInContainer":true`)
+}
+
+func TestBondPluginValidModesMatchNewMasterBondPlugin(t *testing.T) {
+	validModes := []string{
+		bondModeBalanceRR,
+		bondModeActiveBackup,
+		bondModeBalanceXOR,
+		bondModeBalanceTLB,
+		bondModeBalanceALB,
+	}
+
+	for _, mode := range validModes {
+		t.Run(mode, func(t *testing.T) {
+			plugin := BondPlugin(IPAMStatic(), []string{"net1", "net2"}, mode, sysctlBondPluginOptions)
+			assert.NotNil(t, plugin)
+			assert.Equal(t, mode, plugin.Mode)
+
+			masterBond, err := NewMasterBondPlugin("bond0", mode).GetMasterPluginConfig()
+			assert.NoError(t, err)
+			assert.Equal(t, mode, masterBond.Mode)
+		})
+	}
+}


### PR DESCRIPTION
- Add nad.BondPlugin() for bond entries in multi-plugin NAD chains (bond + tuning), like TuningSysctlPlugin.
- Defaults match sysctl/cnf-gotests: active-backup-style config with failOverMac: 1, linksInContainer: true, miimon: "100".
- Optional BondPluginOptions for overriding those fields; opts can be nil.
- Share validBondModes with NewMasterBondPlugin; invalid mode returns nil (caller must check).
- Unit tests added; eco-gotests migration is a follow-up after vendor bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating bond network plugin configurations using IPAM settings, bond ports, and supported bond modes.
  - Added optional settings for failover MAC behavior, container link handling, and link monitoring intervals.
  - Bond configurations use sensible defaults when optional settings are not provided.
  - Configurations now consistently support all valid bond modes.
- **Bug Fixes**
  - Invalid or empty bond modes are rejected consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->