### PR TITLE
pkg/reportxml: Add suite-level properties to XML reports

### DIFF
--- a/pkg/reportxml/reportxml.go
+++ b/pkg/reportxml/reportxml.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/kelseyhightower/envconfig"
@@ -62,17 +63,35 @@ type (
 		CaseTag      string `default:"testcase-id" envconfig:"REPORT_CASE_TAG"`
 		ParameterTag string `default:"parameter" envconfig:"REPORT_PARAMETER_TAG"`
 	}
+
+	// Option configures optional behavior of Create. Options are supplied by the
+	// caller (e.g. eco-gotests), keeping ownership of what gets reported in the
+	// caller rather than in this shared writer.
+	Option func(*createOptions)
+
+	// createOptions accumulates the optional configuration applied by Options.
+	createOptions struct {
+		suiteProperties []Property
+	}
 )
 
 var config *settings
 
 // Create writes report to a given xml file.
-func Create(report ginkgo.Report, destFile, projectTag string) {
+//
+// Optional suite-level properties can be supplied via WithSuiteProperties; the
+// caller owns the allowlist of what to expose.
+func Create(report ginkgo.Report, destFile, projectTag string, opts ...Option) {
 	if destFile == "" {
 		return
 	}
 
-	testSuite := setTestSuite(report)
+	options := &createOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	testSuite := setTestSuite(report, options.suiteProperties)
 
 	for _, testCaseSpecReport := range report.SpecReports {
 		if testCaseSpecReport.FullText() == "" {
@@ -106,6 +125,29 @@ func Create(report ginkgo.Report, destFile, projectTag string) {
 	}
 
 	generateReportXMLFile(destFile, testSuite)
+}
+
+// WithSuiteProperties adds caller-supplied name/value pairs as suite-level
+// <properties> in the JUnit report. The caller (e.g. eco-gotests) owns the
+// allowlist and sources the values from its own configuration. Pairs with an
+// empty name are skipped; the resulting properties are sorted by name for
+// deterministic output, so callers need not sort. Passing no properties (or not
+// using this option) leaves the suite properties empty, so existing consumers
+// see no behavior change.
+func WithSuiteProperties(properties map[string]string) Option {
+	return func(options *createOptions) {
+		for name, value := range properties {
+			if name == "" {
+				continue
+			}
+
+			options.suiteProperties = append(options.suiteProperties, Property{Name: name, Value: value})
+		}
+
+		sort.Slice(options.suiteProperties, func(i, j int) bool {
+			return options.suiteProperties[i].Name < options.suiteProperties[j].Name
+		})
+	}
 }
 
 // ID sets test id for a test case.
@@ -208,14 +250,15 @@ func setSkipMessage(testReport types.SpecReport) *Skipped {
 	return nil
 }
 
-func setTestSuite(report ginkgo.Report) *TestSuite {
+func setTestSuite(report ginkgo.Report, suiteProperties []Property) *TestSuite {
 	return &TestSuite{
-		XMLName:  xml.Name{Space: report.SuiteDescription},
-		Name:     report.SuiteDescription,
-		Tests:    0,
-		Time:     report.RunTime.Seconds(),
-		Skipped:  report.SpecReports.CountWithState(types.SpecStateSkipped),
-		Failures: report.SpecReports.CountWithState(types.SpecStateFailureStates),
+		XMLName:    xml.Name{Space: report.SuiteDescription},
+		Name:       report.SuiteDescription,
+		Tests:      0,
+		Time:       report.RunTime.Seconds(),
+		Skipped:    report.SpecReports.CountWithState(types.SpecStateSkipped),
+		Failures:   report.SpecReports.CountWithState(types.SpecStateFailureStates),
+		Properties: Properties{Property: suiteProperties},
 	}
 }
 

--- a/pkg/reportxml/reportxml_test.go
+++ b/pkg/reportxml/reportxml_test.go
@@ -297,9 +297,107 @@ func TestSetTestSuite(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testSuite := setTestSuite(testCase.report)
+		testSuite := setTestSuite(testCase.report, nil)
 		assert.NotNil(t, testSuite)
 	}
+}
+
+func TestWithSuiteProperties(t *testing.T) {
+	testCases := []struct {
+		name       string
+		properties map[string]string
+		expected   []Property
+	}{
+		{
+			name:       "nil map yields no properties",
+			properties: nil,
+			expected:   nil,
+		},
+		{
+			name:       "empty map yields no properties",
+			properties: map[string]string{},
+			expected:   nil,
+		},
+		{
+			name: "multiple entries sorted by name",
+			properties: map[string]string{
+				"sriov-interfaces": "ens3f0np0,ens3f1np1",
+				"features":         "sriov,ptp",
+				"ptp-interface":    "ens1f0",
+			},
+			expected: []Property{
+				{Name: "features", Value: "sriov,ptp"},
+				{Name: "ptp-interface", Value: "ens1f0"},
+				{Name: "sriov-interfaces", Value: "ens3f0np0,ens3f1np1"},
+			},
+		},
+		{
+			name: "empty name is skipped",
+			properties: map[string]string{
+				"":     "dropped",
+				"kept": "value",
+			},
+			expected: []Property{
+				{Name: "kept", Value: "value"},
+			},
+		},
+		{
+			name: "empty value is preserved",
+			properties: map[string]string{
+				"present-but-empty": "",
+			},
+			expected: []Property{
+				{Name: "present-but-empty", Value: ""},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			opts := &createOptions{}
+			WithSuiteProperties(testCase.properties)(opts)
+			assert.Equal(t, testCase.expected, opts.suiteProperties)
+		})
+	}
+}
+
+func TestSetTestSuiteWithProperties(t *testing.T) {
+	report := ginkgo.Report{
+		SuiteDescription: "test",
+		RunTime:          10 * time.Minute,
+		SpecReports:      types.SpecReports{},
+	}
+	props := []Property{
+		{Name: "features", Value: "sriov,ptp"},
+		{Name: "sriov-interfaces", Value: "ens3f0np0,ens3f1np1"},
+	}
+
+	testSuite := setTestSuite(report, props)
+	assert.NotNil(t, testSuite)
+	assert.Equal(t, props, testSuite.Properties.Property)
+}
+
+func TestCreateWithSuiteProperties(t *testing.T) {
+	destFile := "test-suite-props"
+	report := ginkgo.Report{
+		SuiteDescription: "test",
+		RunTime:          time.Minute,
+		SpecReports:      types.SpecReports{},
+	}
+
+	Create(report, destFile, "TAG", WithSuiteProperties(map[string]string{
+		"sriov-interfaces": "ens3f0np0,ens3f1np1",
+		"features":         "sriov",
+	}))
+
+	assert.FileExists(t, destFile)
+
+	content, err := os.ReadFile(destFile)
+	assert.Nil(t, err)
+	assert.Contains(t, string(content), `name="sriov-interfaces"`)
+	assert.Contains(t, string(content), `value="ens3f0np0,ens3f1np1"`)
+	assert.Contains(t, string(content), `name="features"`)
+	assert.Nil(t, os.RemoveAll(destFile))
 }
 
 func TestCreateNewReportFile(t *testing.T) {


### PR DESCRIPTION
- Introduce `Option` and `createOptions` structs for configurable report creation
- Add `WithSuiteProperties` to include caller-supplied properties in XML output
- Adjust `Create` and `setTestSuite` functions to support suite properties
- Implement unit tests to cover new suite-level properties functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for including custom suite-level properties in generated report XML files.
  - Added an option for configuring property name/value pairs when creating reports.
  - Suite properties are emitted in a consistent name-sorted order, while entries without names are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->